### PR TITLE
Bugfix/error handling login 401

### DIFF
--- a/server/fastify-common.ts
+++ b/server/fastify-common.ts
@@ -113,7 +113,7 @@ fastify.post<{
 
     reply.send({ success: true, message: "Login successful", token });
   } catch (error: any) {
-    reply.code(401).send({ error: error.message });
+    replyError(reply, error);
   }
 });
 

--- a/server/storytelApi.ts
+++ b/server/storytelApi.ts
@@ -21,6 +21,13 @@ interface BookmarkResponse {
   bookmarks: Bookmark[];
 }
 
+interface StorytelAuthError extends Error {
+  isStorytelUnauthorized: boolean;
+  storytelStatus?: number;
+  storytelData?: unknown;
+  isLoginFailure?: boolean;
+}
+
 class StorytelClient {
   private client: AxiosInstance;
   public loginData: LoginData;
@@ -77,6 +84,7 @@ class StorytelClient {
       },
       (error) => {
         const url = error.config?.url || "";
+        const isLoginRequest = url.includes("login.action");
         let cleanUrl = url;
         if (cleanUrl.includes("login.action")) {
           cleanUrl = cleanUrl.replace(/pwd=[^&]+/, "pwd=***");
@@ -92,8 +100,15 @@ class StorytelClient {
         // Propagate Storytel 401 as a distinct error type so Fastify routes
         // can return 401 to the frontend instead of a generic 500.
         if (error.response?.status === 401) {
-          const authError: any = new Error("Storytel session expired");
+          const authError: StorytelAuthError = new Error(
+            isLoginRequest
+              ? "Storytel login rejected"
+              : "Storytel session expired",
+          ) as StorytelAuthError;
           authError.isStorytelUnauthorized = true;
+          authError.isLoginFailure = isLoginRequest;
+          authError.storytelStatus = error.response.status;
+          authError.storytelData = error.response.data;
           return Promise.reject(authError);
         }
         return Promise.reject(error);
@@ -117,6 +132,9 @@ class StorytelClient {
       this.loginData = response.data;
       return this.loginData;
     } catch (error: any) {
+      if (error.isStorytelUnauthorized) {
+        throw error;
+      }
       throw new Error(`Login failed: ${error.message}`);
     }
   }

--- a/server/storytelApi.ts
+++ b/server/storytelApi.ts
@@ -124,11 +124,20 @@ class StorytelClient {
   }
 
   async login(email: string, password: string): Promise<LoginData> {
-    const encryptedPassword = encryptPassword(password.trim());
-    const url = `https://www.storytel.com/api/login.action?m=1&uid=${email.trim()}&pwd=${encryptedPassword}`;
+    const trimmedEmail = email.trim();
+    const trimmedPassword = password.trim();
+    const encryptedPassword = encryptPassword(trimmedPassword);
+    const url = "https://www.storytel.com/api/login.action";
+    const params = {
+      m: 1,
+      uid: trimmedEmail,
+      pwd: encryptedPassword,
+    };
 
     try {
-      const response = await this.client.get<LoginData>(url);
+      const response = await this.client.get<LoginData>(url, {
+        params,
+      });
       this.loginData = response.data;
       return this.loginData;
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Fix Storytel login requests for email addresses containing `+` by sending login data through Axios `params` instead of manually interpolating the query string. This also improves how upstream Storytel `401` auth failures are propagated back through the server.

## Root cause

The login request was previously constructed like this:

```ts
const url = `https://www.storytel.com/api/login.action?m=1&uid=${email.trim()}&pwd=${encryptedPassword}`;
await this.client.get<LoginData>(url);
```

Because the email was inserted directly into the query string, addresses containing special symbols (e.g. `+`) could be interpreted incorrectly by the upstream API. In practice, this caused valid accounts to be rejected with `INVALID_CREDENTIALS` / `User not found`.

## Changes

- Switch the Storytel login request to use Axios `params` in `server/storytelApi.ts`
- Preserve Storytel `401` responses as a dedicated auth error type instead of collapsing them into generic failures
- Distinguish login rejection from session-expiration cases in the Storytel client interceptor
- Return auth failures from `/api/login` through the shared `replyError(...)` path in `server/fastify-common.ts`

## Why this works

Using Axios `params` ensures query values are URL-encoded correctly before the request is sent. That means email addresses like `name+alias@example.com` are transmitted as intended instead of being misparsed by the upstream service.
