### PR TITLE
Add Google and Apple sign-in via Storytel web flow

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -60,7 +60,17 @@ function Dashboard({onLogout, triggerLogout, setTriggerLogout}: DashboardProps) 
             const response = await api.get<BookShelfResponse>('/bookshelf');
             setBooks(response.data.books);
         } catch (error: any) {
-            setError(error.response?.data?.error || t('dashboard.loadError'));
+            // Bookshelf requires Storytel API; on failure (typically offline)
+            // fall back to whatever is cached from previous downloads. If the
+            // offline endpoint responds we trust it even when empty, so the
+            // user sees the normal "no books" empty state instead of the raw
+            // network error.
+            try {
+                const offline = await api.get<BookShelfResponse>('/offline/bookshelf');
+                setBooks(offline.data?.books || []);
+            } catch {
+                setError(error.response?.data?.error || t('dashboard.loadError'));
+            }
         } finally {
             setIsLoading(false);
         }

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -15,8 +15,44 @@ function LoginForm({ onLogin, sessionExpired }: LoginFormProps) {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSsoLoading, setIsSsoLoading] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const ssoAvailable = typeof window !== 'undefined' && !!window.electronAuth;
+
+  const [ssoProvider, setSsoProvider] = useState<'google' | 'apple' | null>(null);
+
+  const handleSsoLogin = async (provider: 'google' | 'apple') => {
+    if (!window.electronAuth) return;
+    setIsSsoLoading(true);
+    setSsoProvider(provider);
+    setError('');
+    try {
+      trackAction('User attempted SSO login', { provider });
+      const result = await window.electronAuth.openSsoWindow(provider);
+      if (result.cancelled) {
+        setIsSsoLoading(false);
+        setSsoProvider(null);
+        return;
+      }
+      if (result.error || !result.credentials) {
+        setError(result.error ?? t('login.errors.failed'));
+        setIsSsoLoading(false);
+        setSsoProvider(null);
+        return;
+      }
+      const response = await api.post('/sso-login', result.credentials);
+      const { token } = response.data;
+      await storage.set('token', token);
+      onLogin();
+      navigate('/');
+    } catch (err: any) {
+      setError(err?.response?.data?.error ?? err?.message ?? t('login.errors.failed'));
+    } finally {
+      setIsSsoLoading(false);
+      setSsoProvider(null);
+    }
+  };
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
@@ -142,6 +178,46 @@ function LoginForm({ onLogin, sessionExpired }: LoginFormProps) {
                 </button>
               </div>
             </form>
+            {ssoAvailable && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 h-px bg-gray-700" />
+                  <span className="text-xs uppercase tracking-wider text-gray-500">
+                    {t('login.ssoDivider')}
+                  </span>
+                  <div className="flex-1 h-px bg-gray-700" />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleSsoLogin('google')}
+                  disabled={isSsoLoading || isLoading}
+                  className="w-full flex items-center justify-center gap-2 py-2 px-4 border border-gray-600 text-sm font-medium rounded-md text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 48 48" aria-hidden="true">
+                    <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.5-5.9 8-11.3 8-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 5.1 29.3 3 24 3 12.4 3 3 12.4 3 24s9.4 21 21 21 21-9.4 21-21c0-1.2-.1-2.4-.4-3.5z"/>
+                    <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 16 19 13 24 13c3.1 0 5.9 1.2 8 3.1l5.7-5.7C34 5.1 29.3 3 24 3 16.3 3 9.7 7.4 6.3 14.7z"/>
+                    <path fill="#4CAF50" d="M24 45c5.2 0 9.9-2 13.4-5.3l-6.2-5.2C29.2 36 26.7 37 24 37c-5.4 0-9.7-3.4-11.3-8.1L6.1 34C9.5 41.6 16.1 45 24 45z"/>
+                    <path fill="#1976D2" d="M43.6 20.5H42V20H24v8h11.3c-.8 2.2-2.2 4.1-4.1 5.5l6.2 5.2c-.4.4 6.6-4.8 6.6-14.2 0-1.2-.1-2.4-.4-3.5z"/>
+                  </svg>
+                  {isSsoLoading && ssoProvider === 'google'
+                    ? t('login.ssoOpening')
+                    : t('login.ssoGoogle')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleSsoLogin('apple')}
+                  disabled={isSsoLoading || isLoading}
+                  className="w-full flex items-center justify-center gap-2 py-2 px-4 border border-gray-600 text-sm font-medium rounded-md text-white bg-gray-800 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+                  </svg>
+                  {isSsoLoading && ssoProvider === 'apple'
+                    ? t('login.ssoOpening')
+                    : t('login.ssoApple')}
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </main>

--- a/client/src/components/PlayerView.tsx
+++ b/client/src/components/PlayerView.tsx
@@ -131,7 +131,8 @@ function PlayerView() {
             trackAction('User initiated download', { bookId: book?.id, bookName: book?.book?.name || "Unknown" });
 
             const response = await api.post('/download', {
-                bookId
+                bookId,
+                book,
             });
 
             if (response && (response as any).data?.success) {

--- a/client/src/hooks/useAudioPlayer.ts
+++ b/client/src/hooks/useAudioPlayer.ts
@@ -1,6 +1,40 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import api, { trackAction } from '../utils/api';
+import storage from '../utils/storage';
 import {BookmarkPositional} from "../interfaces/bookmarks";
+
+interface LocalPosition {
+    position: number;
+    updatedAt: string;
+}
+
+const positionStorageKey = (consumableId: string) => `pos:${consumableId}`;
+
+const readLocalPosition = async (consumableId: string): Promise<LocalPosition | null> => {
+    try {
+        const raw = await storage.get(positionStorageKey(consumableId));
+        if (!raw) return null;
+        const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        if (typeof parsed?.position === 'number' && typeof parsed?.updatedAt === 'string') {
+            return parsed as LocalPosition;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+};
+
+const writeLocalPosition = async (consumableId: string, position: number) => {
+    try {
+        const payload: LocalPosition = {
+            position,
+            updatedAt: new Date().toISOString(),
+        };
+        await storage.set(positionStorageKey(consumableId), JSON.stringify(payload));
+    } catch {
+        // best-effort cache; ignore failures
+    }
+};
 
 interface UseAudioPlayerProps {
     bookId: string | undefined;
@@ -37,29 +71,51 @@ export const useAudioPlayer = ({bookId, consumableId, playbackRate, onLoadError}
     const updatePosition = useCallback(async () => {
         if (!audioRef.current || !consumableId) return;
 
+        const position = Math.floor(audioRef.current.currentTime * 1000);
+        // Always persist locally first so offline listening is not lost.
+        await writeLocalPosition(consumableId, position);
+
         try {
-            const position = Math.floor(audioRef.current.currentTime * 1000);
             await api.put(`/bookmark-positional/${consumableId}`, {position});
         } catch (error) {
-            console.error('Failed to update position:', error);
+            console.warn('Failed to sync position to API, kept locally', error);
         }
     }, [consumableId]);
 
     const goToPosition = useCallback(async () => {
+        // Try remote first, then compare with local cache: the most recent
+        // timestamp wins so a position listened offline is not overwritten
+        // by a stale remote value once the app is online again.
+        let remote: { position: number; updatedAt: string | null } | null = null;
         try {
             const response = await api.get<BookmarkPositional[]>(`/bookmark-positional/${consumableId}`);
-            const {data} = response;
-
-            const position = data?.find(
-                format => format.type === 'abook'
-            )?.position || 0;
-
-            if (audioRef.current) {
-                audioRef.current.currentTime = Math.floor(position / 1000);
-                audioRef.current.play();
+            const entry = response.data?.find(format => format.type === 'abook');
+            if (entry) {
+                remote = {
+                    position: entry.position || 0,
+                    updatedAt: entry.updatedTime || null,
+                };
             }
         } catch (error) {
-            console.error('Failed to go to position:', error);
+            console.warn('Failed to fetch remote position, will use local cache if available', error);
+        }
+
+        const local = await readLocalPosition(consumableId);
+
+        let chosenPosition = 0;
+        if (remote && local) {
+            const remoteTime = remote.updatedAt ? Date.parse(remote.updatedAt) : 0;
+            const localTime = Date.parse(local.updatedAt);
+            chosenPosition = localTime > remoteTime ? local.position : remote.position;
+        } else if (remote) {
+            chosenPosition = remote.position;
+        } else if (local) {
+            chosenPosition = local.position;
+        }
+
+        if (audioRef.current) {
+            audioRef.current.currentTime = Math.floor(chosenPosition / 1000);
+            audioRef.current.play();
         }
     }, [consumableId]);
 

--- a/client/src/hooks/useBookmarks.ts
+++ b/client/src/hooks/useBookmarks.ts
@@ -23,10 +23,14 @@ export const useBookmarks = ({consumableId, onError}: UseBookmarksProps) => {
             const response = await api.get(`/bookmarks/${consumableId}`);
             const {data} = response;
             setBookmarks(data.bookmarks);
-        } catch (error: any) {
-            onError(error.response?.data?.error || 'Failed to load bookmarks');
+        } catch (error) {
+            // Manual bookmarks are not cached locally yet: when the Storytel
+            // API is unreachable we silently degrade to an empty list instead
+            // of blocking the whole PlayerView with an error.
+            console.warn('Failed to load bookmarks, falling back to empty list', error);
+            setBookmarks([]);
         }
-    }, [consumableId, onError]);
+    }, [consumableId]);
 
     const goToBookmark = useCallback((position: number, audioRef: React.RefObject<HTMLAudioElement | null>) => {
         if (audioRef.current) {

--- a/client/src/hooks/useChapters.ts
+++ b/client/src/hooks/useChapters.ts
@@ -15,20 +15,24 @@ export const useChapters = ({consumableId, currentTime, onError}: UseChaptersPro
     const [showChaptersModal, setShowChaptersModal] = useState(false);
 
     const loadChapters = useCallback(async () => {
+        const extractChapters = (data: BookMetaData) =>
+            data.formats?.find(format => format.type === 'abook')?.chapters || [];
+
         try {
             const response = await api.get<BookMetaData>(`/bookmetadata/${consumableId}`);
-            const {data} = response;
-
-            const chapters = data.formats?.find(
-                format => format.type === 'abook'
-            )?.chapters || [];
-
-            setChapters(chapters);
-
+            setChapters(extractChapters(response.data));
         } catch (error: any) {
-            onError(error.response?.data?.error || 'Failed to load chapters');
+            // Fall back to the offline cache persisted at download time.
+            // If even the offline cache is missing we just leave chapters empty
+            // instead of blocking the whole PlayerView with an error state.
+            try {
+                const offline = await api.get<BookMetaData>(`/offline/bookmetadata/${consumableId}`);
+                setChapters(extractChapters(offline.data));
+            } catch {
+                setChapters([]);
+            }
         }
-    }, [consumableId, onError]);
+    }, [consumableId]);
 
     const currentChapter = useMemo(() => {
         let cumulativeTime = 0;

--- a/client/src/types/window.d.ts
+++ b/client/src/types/window.d.ts
@@ -28,5 +28,18 @@ declare global {
       setAlwaysOnTop: (alwaysOnTop: boolean) => Promise<void>;
       isAlwaysOnTop: () => Promise<boolean>;
     };
+    electronAuth?: {
+      openSsoWindow: (provider?: 'google' | 'apple') => Promise<{
+        cancelled: boolean;
+        credentials?: {
+          storytelSession: string;
+          firebaseRefreshToken: string;
+          firebaseApiKey: string;
+          email: string;
+          cid: string;
+        };
+        error?: string;
+      }>;
+    };
   }
 }

--- a/server/fastify-common.ts
+++ b/server/fastify-common.ts
@@ -9,11 +9,42 @@ import path from "path";
 import axios from "axios";
 import { appLogger } from "./logger";
 
-// Extend JWT user type
+// Extend JWT user type. Legacy (email/password) login populates storytelToken
+// and jwt; SSO login populates the sso* fields instead and leaves the legacy
+// ones empty. Email is set in both cases.
 interface JWTUser {
+  email: string;
   storytelToken: string;
   jwt: string;
-  email: string;
+  ssoStorytelSession?: string;
+  ssoFirebaseRefreshToken?: string;
+  ssoFirebaseApiKey?: string;
+  ssoCid?: string;
+}
+
+function hydrateStorytelClient(user: JWTUser): StorytelClient {
+  const client = new StorytelClient();
+  if (
+    user.ssoStorytelSession &&
+    user.ssoFirebaseRefreshToken &&
+    user.ssoFirebaseApiKey
+  ) {
+    client.loginViaSso({
+      storytelSession: user.ssoStorytelSession,
+      firebaseRefreshToken: user.ssoFirebaseRefreshToken,
+      firebaseApiKey: user.ssoFirebaseApiKey,
+      email: user.email,
+      cid: user.ssoCid ?? "",
+    });
+  } else {
+    client.loginData = {
+      accountInfo: {
+        singleSignToken: user.storytelToken ?? "",
+        jwt: user.jwt ?? "",
+      },
+    };
+  }
+  return client;
 }
 
 // Extend FastifyRequest with user property
@@ -117,6 +148,48 @@ fastify.post<{
   }
 });
 
+// Route per SSO login (Google / Apple via Storytel web flow). The Electron
+// SsoManager captures the storytel_session cookie and the Firebase refresh
+// token from the in-app webview after the user completes Storytel's web
+// login, then POSTs them here so we mint our own JWT just like /api/login.
+fastify.post<{
+  Body: {
+    storytelSession: string;
+    firebaseRefreshToken: string;
+    firebaseApiKey: string;
+    email?: string;
+    cid?: string;
+  };
+}>("/api/sso-login", async (request, reply) => {
+  try {
+    const {
+      storytelSession,
+      firebaseRefreshToken,
+      firebaseApiKey,
+      email,
+      cid,
+    } = request.body;
+
+    if (!storytelSession || !firebaseRefreshToken || !firebaseApiKey) {
+      return reply.code(400).send({ error: "Missing SSO credentials" });
+    }
+
+    const token = fastify.jwt.sign({
+      email: email ?? "",
+      storytelToken: "",
+      jwt: "",
+      ssoStorytelSession: storytelSession,
+      ssoFirebaseRefreshToken: firebaseRefreshToken,
+      ssoFirebaseApiKey: firebaseApiKey,
+      ssoCid: cid ?? "",
+    });
+
+    reply.send({ success: true, message: "SSO login successful", token });
+  } catch (error: any) {
+    reply.code(401).send({ error: error.message });
+  }
+});
+
 // Route per logout
 fastify.post("/api/logout", async (_request, reply) => {
   reply.send({ success: true, message: "Logged out successfully" });
@@ -130,14 +203,7 @@ fastify.get(
   },
   async (request, reply) => {
     try {
-      const storytelClient = new StorytelClient();
-
-      storytelClient.loginData = {
-        accountInfo: {
-          singleSignToken: request.user.storytelToken,
-          jwt: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       const bookshelf = await storytelClient.getBookshelf();
       reply.send(bookshelf);
@@ -187,14 +253,7 @@ fastify.post<{
           });
         }
       } else {
-        const storytelClient = new StorytelClient();
-        // Set the login data from JWT token
-        storytelClient.loginData = {
-          accountInfo: {
-            singleSignToken: request.user.storytelToken,
-            jwt: "",
-          },
-        };
+        const storytelClient = hydrateStorytelClient(request.user);
         const streamUrl = await storytelClient.getStreamUrl(bookId);
         reply.send({ streamUrl, remote: true });
       }
@@ -218,14 +277,7 @@ fastify.post<{
       const { consumableId } = request.params;
       const { position, note } = request.body;
 
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       await storytelClient.setBookmark(consumableId, position, note);
 
@@ -246,14 +298,7 @@ fastify.delete<{
   async (request, reply) => {
     try {
       const { consumableId, bookmarkId } = request.params;
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       await storytelClient.deleteBookmark(consumableId, bookmarkId);
 
@@ -275,14 +320,7 @@ fastify.put<{
   async (request, reply) => {
     try {
       const { consumableId, bookmarkId } = request.params;
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       await storytelClient.updateBookmark(
         consumableId,
@@ -304,14 +342,7 @@ fastify.get(
   },
   async (request, reply) => {
     try {
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       const bookmarks = await storytelClient.getBookmarkPositional();
       reply.send(bookmarks);
@@ -332,14 +363,7 @@ fastify.get<{
     try {
       const { consumableId } = request.params;
 
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       const bookmarks =
         await storytelClient.getBookmarkPositional(consumableId);
@@ -363,14 +387,7 @@ fastify.put<{
       const { consumableId } = request.params;
       const { position } = request.body;
 
-      const storytelClient = new StorytelClient();
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       const deviceId =
         process.env.DEVICE_ID || crypto.randomUUID().toUpperCase();
@@ -395,16 +412,8 @@ fastify.get<{
   },
   async (request, reply) => {
     try {
-      const storytelClient = new StorytelClient();
       const { consumableId } = request.params;
-
-      // Set the login data from JWT token
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
 
       const bookmarks = await storytelClient.getBookmark(consumableId);
       reply.send(bookmarks);
@@ -424,14 +433,7 @@ fastify.get<{
   async (request, reply) => {
     try {
       const { consumableId } = request.params;
-      const storytelClient = new StorytelClient();
-
-      storytelClient.loginData = {
-        accountInfo: {
-          jwt: request.user.jwt,
-          singleSignToken: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
       const bookInfoContent =
         await storytelClient.getPlayBookMetaData(consumableId);
       reply.send(bookInfoContent);
@@ -546,13 +548,7 @@ fastify.post<{
       }
 
       // Get stream URL
-      const storytelClient = new StorytelClient();
-      storytelClient.loginData = {
-        accountInfo: {
-          singleSignToken: request.user.storytelToken,
-          jwt: "",
-        },
-      };
+      const storytelClient = hydrateStorytelClient(request.user);
       const streamUrl = await storytelClient.getStreamUrl(bookId);
 
       // Create AbortController for this download

--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -6,6 +6,10 @@
     "password": "Password",
     "signIn": "Sign in",
     "signingIn": "Signing in...",
+    "ssoDivider": "or",
+    "ssoGoogle": "Continue with Google",
+    "ssoApple": "Continue with Apple",
+    "ssoOpening": "Opening Storytel login...",
     "errors": {
       "required": "Please enter both email and password",
       "failed": "Login failed",

--- a/server/locales/it.json
+++ b/server/locales/it.json
@@ -6,6 +6,10 @@
     "password": "Password",
     "signIn": "Accedi",
     "signingIn": "Accesso in corso...",
+    "ssoDivider": "oppure",
+    "ssoGoogle": "Continua con Google",
+    "ssoApple": "Continua con Apple",
+    "ssoOpening": "Apertura login Storytel...",
     "errors": {
       "required": "Inserisci sia email che password",
       "failed": "Accesso fallito",

--- a/server/storytelApi.ts
+++ b/server/storytelApi.ts
@@ -21,9 +21,26 @@ interface BookmarkResponse {
   bookmarks: Bookmark[];
 }
 
+export interface SsoSession {
+  storytelSession: string;
+  firebaseRefreshToken: string;
+  firebaseApiKey: string;
+  email: string;
+  cid: string;
+}
+
+const FIREBASE_TOKEN_URL = 'https://securetoken.googleapis.com';
+// The Storytel Firebase API key is browser-restricted: requests without a
+// matching Referer get 403 API_KEY_HTTP_REFERRER_BLOCKED. The Web SDK runs
+// on www.storytel.com, so we mimic that origin from the server.
+const FIREBASE_REFERER = 'https://www.storytel.com/';
+const FIREBASE_ID_TOKEN_TTL_BUFFER_SECONDS = 60;
+
 class StorytelClient {
   private client: AxiosInstance;
   public loginData: LoginData;
+  private ssoSession: SsoSession | null = null;
+  private cachedFirebaseIdToken: { token: string; expiresAt: number } | null = null;
 
   constructor() {
     this.client = axios.create({
@@ -115,10 +132,89 @@ class StorytelClient {
     try {
       const response = await this.client.get<LoginData>(url);
       this.loginData = response.data;
+      this.ssoSession = null;
+      this.cachedFirebaseIdToken = null;
       return this.loginData;
     } catch (error: any) {
       throw new Error(`Login failed: ${error.message}`);
     }
+  }
+
+  loginViaSso(session: SsoSession): void {
+    this.ssoSession = session;
+    this.cachedFirebaseIdToken = null;
+    // Mark legacy credentials as unset so any accidental fallback path errors
+    // visibly instead of using stale data.
+    this.loginData = {
+      accountInfo: { jwt: '', singleSignToken: '' },
+    };
+  }
+
+  getSsoSession(): SsoSession | null {
+    return this.ssoSession;
+  }
+
+  // Token to send as ?token=... on the legacy *.action endpoints. In SSO mode
+  // we substitute the Firebase Session Cookie, which the Storytel API treats
+  // interchangeably with the singleSignToken returned by login.action.
+  private getLegacyActionToken(): string {
+    if (this.ssoSession) return this.ssoSession.storytelSession;
+    return this.loginData.accountInfo.singleSignToken;
+  }
+
+  private async ensureFirebaseIdToken(): Promise<string> {
+    if (!this.ssoSession) {
+      throw new Error('ensureFirebaseIdToken called outside SSO mode');
+    }
+    const now = Math.floor(Date.now() / 1000);
+    const cached = this.cachedFirebaseIdToken;
+    if (cached && cached.expiresAt - FIREBASE_ID_TOKEN_TTL_BUFFER_SECONDS > now) {
+      return cached.token;
+    }
+    const params = new URLSearchParams();
+    params.set('grant_type', 'refresh_token');
+    params.set('refresh_token', this.ssoSession.firebaseRefreshToken);
+    try {
+      const response = await axios.post<{
+        access_token: string;
+        expires_in: string;
+        refresh_token?: string;
+      }>(
+        `${FIREBASE_TOKEN_URL}/v1/token?key=${this.ssoSession.firebaseApiKey}`,
+        params.toString(),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Referer: FIREBASE_REFERER,
+            Origin: 'https://www.storytel.com',
+          },
+          timeout: 15000,
+        }
+      );
+      const accessToken = response.data.access_token;
+      const expiresIn = parseInt(response.data.expires_in, 10) || 3600;
+      this.cachedFirebaseIdToken = {
+        token: accessToken,
+        expiresAt: now + expiresIn,
+      };
+      return accessToken;
+    } catch (error: any) {
+      const status = error.response?.status;
+      if (status === 400 || status === 401 || status === 403) {
+        const authError: any = new Error('Firebase refresh token rejected');
+        authError.isStorytelUnauthorized = true;
+        throw authError;
+      }
+      throw new Error(`Firebase token refresh failed: ${error.message}`);
+    }
+  }
+
+  // Bearer to send on api.storytel.net/* endpoints. SSO mode: fresh Firebase
+  // ID token (auto-refreshed via the long-lived refresh token). Legacy mode:
+  // the JWT returned by login.action.
+  private async getApiBearer(): Promise<string> {
+    if (this.ssoSession) return this.ensureFirebaseIdToken();
+    return this.loginData.accountInfo.jwt;
   }
 
   async getBookmarkPositional(
@@ -127,12 +223,13 @@ class StorytelClient {
     const url = `https://api.storytel.net/bookmarks/positional?kidsMode=false&orderBy=updated&orderDirection=desc`;
 
     try {
+      const bearer = await this.getApiBearer();
       const response = await this.client.get<{ bookmarks: Bookmark[] }>(url, {
         params: {
           ...(consumableId && { consumableIds: consumableId }),
         },
         headers: {
-          Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+          Authorization: `Bearer ${bearer}`,
         },
       });
       return response.data.bookmarks;
@@ -150,6 +247,7 @@ class StorytelClient {
     const url = `https://api.storytel.net/bookmarks/positional`;
 
     try {
+      const bearer = await this.getApiBearer();
       const response = await this.client.post(
         url,
         {
@@ -163,7 +261,7 @@ class StorytelClient {
         },
         {
           headers: {
-            Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+            Authorization: `Bearer ${bearer}`,
           },
         },
       );
@@ -175,7 +273,7 @@ class StorytelClient {
   }
 
   async getBookshelf(): Promise<any> {
-    const url = `https://www.storytel.com/api/getBookShelf.action?token=${this.loginData.accountInfo.singleSignToken}`;
+    const url = `https://www.storytel.com/api/getBookShelf.action?token=${encodeURIComponent(this.getLegacyActionToken())}`;
 
     try {
       const response = await this.client.get(url);
@@ -196,9 +294,10 @@ class StorytelClient {
     const url = `https://api.storytel.net/playback-metadata/consumable/${consumableId}`;
 
     try {
+      const bearer = await this.getApiBearer();
       const response = await this.client.get(url, {
         headers: {
-          Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+          Authorization: `Bearer ${bearer}`,
         },
       });
       return response.data;
@@ -209,7 +308,7 @@ class StorytelClient {
   }
 
   async getStreamUrl(bookId: string): Promise<string> {
-    const url = `https://www.storytel.com/mp3streamRangeReq?startposition=0&programId=${bookId}&token=${this.loginData.accountInfo.singleSignToken}`;
+    const url = `https://www.storytel.com/mp3streamRangeReq?startposition=0&programId=${bookId}&token=${encodeURIComponent(this.getLegacyActionToken())}`;
 
     try {
       const response = await this.client.get(url);
@@ -229,9 +328,10 @@ class StorytelClient {
     const url = `https://api.storytel.net/bookmarks/manual?type=abook&consumableId=${consumableId}`;
 
     try {
+      const bearer = await this.getApiBearer();
       const response = await this.client.get<BookmarkResponse>(url, {
         headers: {
-          Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+          Authorization: `Bearer ${bearer}`,
           Accept: "application/vnd.storytel.bookmark+json;v=2.0",
         },
       });
@@ -249,6 +349,7 @@ class StorytelClient {
   ): Promise<void> {
     const url = "https://api.storytel.net/bookmarks/manual";
     try {
+      const bearer = await this.getApiBearer();
       await this.client.post(
         url,
         {
@@ -259,7 +360,7 @@ class StorytelClient {
         },
         {
           headers: {
-            Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+            Authorization: `Bearer ${bearer}`,
             Accept: "application/vnd.storytel.bookmark+json;v=2.0",
           },
         },
@@ -286,9 +387,10 @@ class StorytelClient {
 
     const url = `https://api.storytel.net/bookmarks/manual/${bookmarkId}?id=${bookmarkId}`;
     try {
+      const bearer = await this.getApiBearer();
       await this.client.put(url, bookmarkData, {
         headers: {
-          Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+          Authorization: `Bearer ${bearer}`,
           Accept: "application/vnd.storytel.bookmark+json;v=2.0",
         },
       });
@@ -313,9 +415,10 @@ class StorytelClient {
 
     const url = `https://api.storytel.net/bookmarks/manual/${bookmarkId}?id=${bookmarkId}`;
     try {
+      const bearer = await this.getApiBearer();
       await this.client.delete(url, {
         headers: {
-          Authorization: `Bearer ${this.loginData.accountInfo.jwt}`,
+          Authorization: `Bearer ${bearer}`,
           Accept: "application/vnd.storytel.bookmark+json;v=2.0",
         },
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {TrayManager} from './modules/tray';
 import {ServerManager} from './modules/server';
 import {IpcManager} from './modules/ipc';
 import {UpdaterManager} from './modules/updater';
+import {SsoManager} from './modules/sso';
 import {i18n} from './i18n';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -14,6 +15,7 @@ let trayManager: TrayManager;
 let serverManager: ServerManager;
 let ipcManager: IpcManager;
 let updaterManager: UpdaterManager;
+let ssoManager: SsoManager;
 
 async function initialize(): Promise<void> {
 
@@ -38,7 +40,9 @@ async function initialize(): Promise<void> {
     trayManager = new TrayManager(windowManager);
     trayManager.create();
 
-    ipcManager = new IpcManager(serverManager, trayManager, windowManager);
+    ssoManager = new SsoManager();
+
+    ipcManager = new IpcManager(serverManager, trayManager, windowManager, ssoManager);
     ipcManager.setupHandlers();
 
     // Initialize auto-updater

--- a/src/modules/ipc.ts
+++ b/src/modules/ipc.ts
@@ -4,6 +4,7 @@ import { storeManager } from './store';
 import { ServerManager } from './server';
 import { TrayManager } from './tray';
 import { WindowManager } from './window';
+import { SsoManager } from './sso';
 import { ApiConfig } from '../types';
 import { i18n } from '../i18n';
 
@@ -11,11 +12,18 @@ export class IpcManager {
   private serverManager: ServerManager;
   private trayManager: TrayManager;
   private windowManager: WindowManager;
+  private ssoManager: SsoManager;
 
-  constructor(serverManager: ServerManager, trayManager: TrayManager, windowManager: WindowManager) {
+  constructor(
+    serverManager: ServerManager,
+    trayManager: TrayManager,
+    windowManager: WindowManager,
+    ssoManager: SsoManager
+  ) {
     this.serverManager = serverManager;
     this.trayManager = trayManager;
     this.windowManager = windowManager;
+    this.ssoManager = ssoManager;
   }
 
   setupHandlers(): void {
@@ -25,6 +33,7 @@ export class IpcManager {
     this.setupLocaleHandlers();
     this.setupWindowHandlers();
     this.setupLogsHandlers();
+    this.setupAuthHandlers();
   }
 
   private setupStoreHandlers(): void {
@@ -158,5 +167,15 @@ export class IpcManager {
     ipcMain.handle('window-is-always-on-top', () => {
       return this.windowManager.isAlwaysOnTop();
     });
+  }
+
+  private setupAuthHandlers(): void {
+    ipcMain.handle(
+      'auth:open-sso-window',
+      async (_event: IpcMainInvokeEvent, provider?: 'google' | 'apple') => {
+        const parent = this.windowManager.getWindow();
+        return this.ssoManager.openSsoWindow(parent, provider);
+      }
+    );
   }
 }

--- a/src/modules/sso.ts
+++ b/src/modules/sso.ts
@@ -1,0 +1,308 @@
+import { BrowserWindow, session } from 'electron';
+
+export type SsoProvider = 'google' | 'apple';
+
+export interface SsoCredentials {
+  storytelSession: string;
+  firebaseRefreshToken: string;
+  firebaseApiKey: string;
+  email: string;
+  cid: string;
+}
+
+export interface SsoLoginResult {
+  cancelled: boolean;
+  credentials?: SsoCredentials;
+  error?: string;
+}
+
+const STORYTEL_LOGIN_URL = 'https://www.storytel.com/it/login';
+const STORYTEL_HOST = 'storytel.com';
+const SSO_PARTITION = 'persist:storytel-sso';
+// Any page on www.storytel.com works for reading the Firebase IndexedDB; we
+// pick the locale root because it always exists (no 404 redirect).
+const STORYTEL_WWW_STORAGE_TARGET = 'https://www.storytel.com/it/';
+
+const FIREBASE_AUTH_PATH = /^\/__\/auth\//;
+const LOGIN_PATH = /^\/[a-z]{2,3}\/login(\/|$)/;
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+// Time to let the SPA settle after landing on a post-login page before we
+// trigger the controlled navigation to www.storytel.com for the IDB read.
+const POST_LOGIN_SETTLE_MS = 1500;
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const json = Buffer.from(parts[1], 'base64url').toString('utf8');
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+// Click the Storytel login page's provider button. The page is not under our
+// control, so the selector is best-effort: we look for any clickable element
+// whose visible text or aria-label mentions the provider name. Polls for up to
+// `maxAttempts * intervalMs` (~5s) before giving up — if it never matches, the
+// user can still click manually inside the webview.
+function buildProviderClickScript(provider: SsoProvider): string {
+  return `
+    (async () => {
+      const target = ${JSON.stringify(provider)};
+      const needles = target === 'google'
+        ? ['google']
+        : ['apple'];
+      const findAndClick = () => {
+        const candidates = Array.from(
+          document.querySelectorAll('button, a, [role="button"]')
+        );
+        for (const el of candidates) {
+          const text = (el.textContent || '').toLowerCase().trim();
+          const aria = (el.getAttribute('aria-label') || '').toLowerCase();
+          const haystack = text + ' ' + aria;
+          if (needles.some(n => haystack.includes(n)) && text.length < 60) {
+            el.click();
+            return true;
+          }
+        }
+        return false;
+      };
+      for (let i = 0; i < 25; i++) {
+        if (findAndClick()) return true;
+        await new Promise(r => setTimeout(r, 200));
+      }
+      return false;
+    })()
+  `;
+}
+
+export class SsoManager {
+  private window: BrowserWindow | null = null;
+
+  private async clearStorytelState(ssoSession: Electron.Session): Promise<void> {
+    try {
+      // Remove every cookie scoped to storytel.com (covers .storytel.com,
+      // www.storytel.com, private.storytel.com).
+      const cookies = await ssoSession.cookies.get({ domain: STORYTEL_HOST });
+      await Promise.all(
+        cookies.map((c) => {
+          const host = (c.domain ?? '').replace(/^\./, '') || STORYTEL_HOST;
+          const url = `${c.secure ? 'https' : 'http'}://${host}${c.path ?? '/'}`;
+          return ssoSession.cookies.remove(url, c.name).catch(() => undefined);
+        })
+      );
+    } catch (err) {
+      console.error('[sso] failed to clear storytel cookies:', err);
+    }
+    // Clear IndexedDB / localStorage / sessionStorage on the storytel origins
+    // (this is where the Firebase Web SDK persists the authenticated user).
+    const origins = [
+      'https://www.storytel.com',
+      'https://private.storytel.com',
+    ];
+    for (const origin of origins) {
+      try {
+        await ssoSession.clearStorageData({
+          origin,
+          storages: ['indexdb', 'localstorage'],
+        });
+      } catch (err) {
+        console.error(`[sso] failed to clear storage for ${origin}:`, err);
+      }
+    }
+  }
+
+  async openSsoWindow(
+    parent?: BrowserWindow | null,
+    provider?: SsoProvider
+  ): Promise<SsoLoginResult> {
+    if (this.window) {
+      this.window.focus();
+      return { cancelled: true };
+    }
+
+    const ssoSession = session.fromPartition(SSO_PARTITION);
+    ssoSession.setUserAgent(DESKTOP_UA);
+
+    // Wipe any prior Storytel session so the provider picker is shown again.
+    // We deliberately leave accounts.google.com / appleid.apple.com cookies
+    // intact so the user isn't forced to re-enter the OAuth provider password.
+    await this.clearStorytelState(ssoSession);
+
+    this.window = new BrowserWindow({
+      width: 520,
+      height: 720,
+      parent: parent ?? undefined,
+      modal: false,
+      autoHideMenuBar: true,
+      webPreferences: {
+        partition: SSO_PARTITION,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    this.window.webContents.setUserAgent(DESKTOP_UA);
+
+    await this.window.loadURL(STORYTEL_LOGIN_URL);
+
+    if (provider) {
+      // Fire-and-forget: don't block the SSO flow if the click script fails.
+      // The user can still pick a provider manually inside the webview.
+      this.window.webContents
+        .executeJavaScript(buildProviderClickScript(provider), true)
+        .catch((err) => console.error('[sso] provider click failed:', err));
+    }
+
+    return new Promise<SsoLoginResult>((resolve) => {
+      const win = this.window!;
+      let settled = false;
+      let inCaptureFlow = false;
+      let scheduledCapture: NodeJS.Timeout | null = null;
+
+      const finish = (result: SsoLoginResult): void => {
+        if (settled) return;
+        settled = true;
+        if (scheduledCapture) {
+          clearTimeout(scheduledCapture);
+          scheduledCapture = null;
+        }
+        try {
+          if (!win.isDestroyed()) win.close();
+        } catch {
+          // ignore
+        }
+        this.window = null;
+        resolve(result);
+      };
+
+      const extractFirebaseRefreshToken = async (): Promise<{
+        refreshToken: string;
+        apiKey: string;
+      } | null> => {
+        const result = await win.webContents.executeJavaScript(
+          `(async () => {
+            try {
+              const db = await new Promise((res, rej) => {
+                const req = indexedDB.open('firebaseLocalStorageDb');
+                req.onsuccess = e => res(e.target.result);
+                req.onerror = e => rej((e.target && e.target.error) || new Error('open failed'));
+              });
+              const storeNames = Array.from(db.objectStoreNames);
+              if (!storeNames.includes('firebaseLocalStorage')) {
+                db.close();
+                return null;
+              }
+              const entries = await new Promise((res, rej) => {
+                const tx = db.transaction('firebaseLocalStorage', 'readonly');
+                const s = tx.objectStore('firebaseLocalStorage');
+                const req = s.getAll();
+                req.onsuccess = () => res(req.result);
+                req.onerror = e => rej((e.target && e.target.error) || new Error('getAll failed'));
+              });
+              db.close();
+              for (const entry of entries) {
+                const key = entry && entry.fbase_key;
+                if (typeof key === 'string' && key.startsWith('firebase:authUser:') && key.endsWith(':[DEFAULT]')) {
+                  const apiKey = key.slice('firebase:authUser:'.length, key.length - ':[DEFAULT]'.length);
+                  const refresh = entry && entry.value && entry.value.stsTokenManager && entry.value.stsTokenManager.refreshToken;
+                  if (refresh) return { refreshToken: refresh, apiKey };
+                }
+              }
+              return null;
+            } catch (e) {
+              return null;
+            }
+          })()`,
+          true
+        );
+        return result ?? null;
+      };
+
+      const capture = async (): Promise<void> => {
+        if (settled || win.isDestroyed() || inCaptureFlow) return;
+        inCaptureFlow = true;
+        try {
+          const cookies = await ssoSession.cookies.get({ domain: STORYTEL_HOST });
+          const sessionCookie = cookies.find((c) => c.name === 'storytel_session');
+          if (!sessionCookie || !sessionCookie.value) {
+            finish({
+              cancelled: false,
+              error: 'storytel_session cookie not found after login',
+            });
+            return;
+          }
+
+          // Read identity claims from the session cookie (it is itself a JWT).
+          const claims = decodeJwtPayload(sessionCookie.value);
+          const email = typeof claims?.email === 'string' ? claims.email : '';
+          const cid = typeof claims?.cid === 'string' ? claims.cid : '';
+
+          // Navigate to www.storytel.com to read its IndexedDB (Firebase Web SDK origin).
+          const currentHost = new URL(win.webContents.getURL()).hostname;
+          if (currentHost !== 'www.storytel.com') {
+            await win.webContents.loadURL(STORYTEL_WWW_STORAGE_TARGET);
+            await new Promise((r) => setTimeout(r, 800));
+          }
+
+          const fb = await extractFirebaseRefreshToken();
+          if (!fb) {
+            finish({
+              cancelled: false,
+              error: 'Firebase refresh token not found in IndexedDB',
+            });
+            return;
+          }
+
+          finish({
+            cancelled: false,
+            credentials: {
+              storytelSession: sessionCookie.value,
+              firebaseRefreshToken: fb.refreshToken,
+              firebaseApiKey: fb.apiKey,
+              email,
+              cid,
+            },
+          });
+        } catch (err: unknown) {
+          finish({
+            cancelled: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      };
+
+      const scheduleCapture = (): void => {
+        if (settled || scheduledCapture || inCaptureFlow) return;
+        scheduledCapture = setTimeout(() => {
+          scheduledCapture = null;
+          void capture();
+        }, POST_LOGIN_SETTLE_MS);
+      };
+
+      const maybeAutoCapture = (url: string): void => {
+        if (inCaptureFlow) return;
+        try {
+          const parsed = new URL(url);
+          if (!parsed.hostname.endsWith(STORYTEL_HOST)) return;
+          if (FIREBASE_AUTH_PATH.test(parsed.pathname)) return;
+          if (LOGIN_PATH.test(parsed.pathname)) return;
+          scheduleCapture();
+        } catch {
+          // ignore unparseable urls
+        }
+      };
+
+      win.webContents.on('did-navigate', (_e, url) => maybeAutoCapture(url));
+      win.webContents.on('did-navigate-in-page', (_e, url) => maybeAutoCapture(url));
+      win.on('closed', () => {
+        finish({ cancelled: true });
+      });
+    });
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -63,3 +63,24 @@ contextBridge.exposeInMainWorld('electronApi', {
   delete: (url: string, _: any, config?: ApiConfig): Promise<any> =>
     ipcRenderer.invoke('api:delete', url, config),
 });
+
+// Auth / SSO API
+interface SsoCredentials {
+  storytelSession: string;
+  firebaseRefreshToken: string;
+  firebaseApiKey: string;
+  email: string;
+  cid: string;
+}
+interface SsoLoginResult {
+  cancelled: boolean;
+  credentials?: SsoCredentials;
+  error?: string;
+}
+
+type SsoProvider = 'google' | 'apple';
+
+contextBridge.exposeInMainWorld('electronAuth', {
+  openSsoWindow: (provider?: SsoProvider): Promise<SsoLoginResult> =>
+    ipcRenderer.invoke('auth:open-sso-window', provider),
+});


### PR DESCRIPTION
Closes #14

## What this changes

Adds Google and Apple sign-in alongside the existing email/password login. The user picks a provider on the login screen; an Electron `BrowserWindow` opens Storytel's web login (`storytel.com/it/login`), auto-clicks the provider button, lets the user complete the OAuth dance, and pulls back the two credentials the rest of the app needs.

The two-credentials part matters because Storytel's APIs come in two flavours:

- `www.storytel.com/api/*.action` (the legacy mobile API the app already uses) accepts the `storytel_session` Firebase session cookie, either as a cookie or as the existing `?token=` query param. Verified by hitting `getBookShelf.action` both ways — 200 with the real bookshelf back.
- `api.storytel.net/*` (bookmarks, playback metadata) rejects the session cookie. It wants a Firebase ID token in `Authorization: Bearer`. Verified by replaying the call after swapping credentials: 401 → 200 with real bookmark data.

So the in-app webview captures both:

1. The `storytel_session` cookie via `session.cookies.get({ domain: 'storytel.com' })`.
2. The Firebase refresh token, read out of IndexedDB on the `www.storytel.com` origin (`firebaseLocalStorageDb` → object store `firebaseLocalStorage` → entry keyed `firebase:authUser:<apiKey>:[DEFAULT]`, field `stsTokenManager.refreshToken`). Firebase Web SDK v9+ persists auth state there, not in `localStorage` — which is what threw us off in the first probing round.

Both get POSTed to a new `/api/sso-login` endpoint that mints our JWT, same envelope as `/api/login` plus a few SSO fields. The `StorytelClient` then selects credentials per call: legacy `.action` endpoints get the session cookie value as `?token=`, anything on `api.storytel.net` gets a fresh Firebase ID token, refreshed on demand via `securetoken.googleapis.com/v1/token` using the long-lived refresh token.

## Things we ran into

A few non-obvious things came up while figuring this out:

- **Google's embedded-webview block didn't fire.** With a desktop Chrome user-agent on the SSO `session`, Google's identifier page renders inside the `BrowserWindow` and the full OAuth flow completes in-app. We expected this to be the blocker; it wasn't.
- **The Firebase API key is browser-restricted.** Direct calls to `securetoken.googleapis.com/v1/token` from the Node side returned `403 API_KEY_HTTP_REFERRER_BLOCKED` until we set `Referer: https://www.storytel.com/` (and `Origin`) on the request. The Web SDK gets this for free because it runs on that origin; server-side we spoof it explicitly.
- **`private.storytel.com` is Next.js App Router with server-rendered React Server Components.** The browser never sees a `Bearer` token there — all API access is brokered server-side via the cookie — so for a while we were chasing an `Authorization` header that doesn't exist. Once we redirected the capture step to `www.storytel.com` (where the Firebase Web SDK actually lives), the IndexedDB read worked.
- **State leaked between provider switches.** The persisted SSO session would auto-log the user back in as the previous provider, defeating the new "Continue with Apple" button after a Google sign-out. Fix wipes Storytel cookies, IndexedDB and localStorage before each `openSsoWindow`, but deliberately leaves `accounts.google.com` / `appleid.apple.com` state intact so the OAuth password prompt isn't asked every single time.

## Accepted limitations

- `storytel_session` lasts 24h. When it expires, `.action` endpoints return 401 and the existing interceptor surfaces it as session-expired → user is sent back to the login screen and re-does SSO. Same behaviour as today's email/password flow.
- Firebase's refresh-token exchange sometimes rotates the refresh token. We currently keep the original; if it ever stops working the user re-authenticates. Cheaper than persisting rotations back into the JWT.
- Auto-clicking the provider button on Storytel's page is best-effort (matches by visible text and aria-label). If Storytel reshuffles their login UI the user can still click manually inside the webview.

## Bundled in this PR

Also folds in some offline-fallback work that was in flight on the same branch: cached bookshelf at `/api/offline/bookshelf`, cached chapters at `/api/offline/bookmetadata/:consumableId`, and the matching client-side fallback paths in `Dashboard` and `useChapters`. Calling it out for completeness — the bulk of the diff is still SSO.

## Test plan

- [x] Sign in with Google from a clean SSO partition — lands on the library, bookshelf loads.
- [x] Open a book — chapters and stream URL fetch correctly (exercises both API families).
- [ ] Sign out from the app, click "Continue with Apple" — no auto-login as the Google user.
- [ ] Leave the app running for >1h and play a different book — exercises the Firebase ID token refresh path on `api.storytel.net` calls.
- [ ] Kill network, re-open the app — offline bookshelf and cached chapters still render.

---

Investigated and built with help from Claude.
