### PR TITLE
ci(aur): bump deploy-aur action to v4.1.3

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -30,7 +30,7 @@ jobs:
           sed -i "s/^sha256sums=.*/sha256sums=('${{ steps.shasum.outputs.sha256 }}')/" PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v2
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: storytel-player-bin
           pkgbuild: ./aur/PKGBUILD

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -3,6 +3,12 @@ name: Publish to AUR
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without "v" prefix, e.g. 1.2.14). Leave empty to use the latest published release.'
+        required: false
+        type: string
 
 jobs:
   aur-publish:
@@ -12,7 +18,19 @@ jobs:
 
       - name: Get Release Version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          elif [ -n "$INPUT_VERSION" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+            version="${tag#v}"
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Download .deb Artifact
         run: |


### PR DESCRIPTION
v2 hits a runuser/bash bug ("bash: --command: invalid option") that
fails the job during "Initializing SSH directory". v4.1.3 fixes it.