### PR TITLE
Add pre-release workflow for manual and PR builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,119 @@
+name: Pre-Release
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  push:
+    tags:
+      # Only pre-release semver tags (those carrying a "-" suffix, e.g. v1.3.0-beta.1).
+      - "v*-*"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to build (from any fork). Builds from refs/pull/<N>/head and is ALWAYS marked as prerelease."
+        required: false
+      tag_name:
+        description: "Tag/release name (e.g. v1.3.0-beta.1). Required when pr_number is set."
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.meta.outputs.ref }}
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Resolve build ref + tag
+        id: meta
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            # Fork/PR builds: check out the PR head and require an explicit tag.
+            if [ -z "${{ inputs.tag_name }}" ]; then
+              echo "::error::tag_name is required when pr_number is provided"
+              exit 1
+            fi
+            echo "ref=refs/pull/${{ inputs.pr_number }}/head" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag_name }}"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag_name || github.ref_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # electron-builder derives its release tag from package.json version (v<version>),
+          # so we strip the leading "v" to feed it back in during the build step.
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-latest
+            script: electron:dist:linux:x64
+          - name: linux-arm64
+            os: ubuntu-latest
+            script: electron:dist:linux:arm64
+          - name: linux-arm
+            os: ubuntu-latest
+            script: electron:dist:linux:arm
+          - name: mac-x64
+            os: macos-latest
+            script: electron:dist:mac:x64
+          - name: mac-arm64
+            os: macos-latest
+            script: electron:dist:mac:arm64
+          - name: win
+            os: windows-latest
+            script: electron:dist:win
+
+    runs-on: ${{ matrix.os }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Apply pre-release version + flag
+        env:
+          REL_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # Pin the package.json version to the requested tag and force every
+          # publish target to "prerelease" so the GitHub release is flagged as such.
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.version = process.env.REL_VERSION;
+            const markPrerelease = (node) => {
+              if (!node || typeof node !== "object") return;
+              if (node.publish && node.publish.releaseType) node.publish.releaseType = "prerelease";
+              for (const key of Object.keys(node)) markPrerelease(node[key]);
+            };
+            markPrerelease(pkg.build || {});
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("Building pre-release v" + pkg.version);
+          '
+
+      - name: Build
+        run: npm run install-all
+
+      - name: Publish pre-release
+        run: npm run ${{ matrix.script }} -- --publish always


### PR DESCRIPTION
Adds a dedicated workflow to publish pre-releases, separate from the master build pipeline.

It triggers in two ways:

- Pushing a pre-release semver tag (anything with a `-` suffix, e.g. `v1.3.0-beta.1`). Stable tags are left untouched.
- Manual dispatch, optionally pointing at a PR number so we can build straight from a fork's branch.

A `prepare` job resolves the ref, tag and version once and hands them to the build matrix (linux x64/arm64/arm, mac x64/arm64, win). Before building, each runner pins `package.json` to the requested version and flips every `publish.releaseType` to `prerelease`, since electron-builder derives the release tag and flag from there rather than from CLI args.

This makes it easy to hand out test builds from a PR without touching the stable release flow.
