### PR TITLE
Release 1.2.15

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -30,7 +30,7 @@ jobs:
           sed -i "s/^sha256sums=.*/sha256sums=('${{ steps.shasum.outputs.sha256 }}')/" PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v2
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: storytel-player-bin
           pkgbuild: ./aur/PKGBUILD

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -3,6 +3,12 @@ name: Publish to AUR
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without "v" prefix, e.g. 1.2.14). Leave empty to use the latest published release.'
+        required: false
+        type: string
 
 jobs:
   aur-publish:
@@ -12,7 +18,19 @@ jobs:
 
       - name: Get Release Version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          elif [ -n "$INPUT_VERSION" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+            version="${tag#v}"
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Download .deb Artifact
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,20 @@ jobs:
       - name: Build
         run: npm run install-all
 
+      # Notarization uses the App Store Connect API key. The .p8 is stored
+      # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file.
+      - name: Prepare Apple API key
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       - name: Release
         if: contains(github.ref, 'master')
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npm run electron:dist:mac:x64 -- --publish always
 
   dmg_arm64:
@@ -104,8 +116,20 @@ jobs:
       - name: Build
         run: npm run install-all
 
+      # Notarization uses the App Store Connect API key. The .p8 is stored
+      # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file.
+      - name: Prepare Apple API key
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       - name: Release
         if: contains(github.ref, 'master')
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npm run electron:dist:mac:arm64 -- --publish always
 
   exe:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -141,5 +141,19 @@ jobs:
       - name: Build
         run: npm run install-all
 
+      # macOS notarization uses the App Store Connect API key. The .p8 is stored
+      # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file.
+      - name: Prepare Apple API key (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       - name: Publish pre-release
+        env:
+          # Scoped to macOS jobs only; empty elsewhere so Windows/Linux signing is untouched.
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPLE_API_ISSUER || '' }}
         run: npm run ${{ matrix.script }} -- --publish always

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,119 @@
+name: Pre-Release
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  push:
+    tags:
+      # Only pre-release semver tags (those carrying a "-" suffix, e.g. v1.3.0-beta.1).
+      - "v*-*"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to build (from any fork). Builds from refs/pull/<N>/head and is ALWAYS marked as prerelease."
+        required: false
+      tag_name:
+        description: "Tag/release name (e.g. v1.3.0-beta.1). Required when pr_number is set."
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.meta.outputs.ref }}
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Resolve build ref + tag
+        id: meta
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            # Fork/PR builds: check out the PR head and require an explicit tag.
+            if [ -z "${{ inputs.tag_name }}" ]; then
+              echo "::error::tag_name is required when pr_number is provided"
+              exit 1
+            fi
+            echo "ref=refs/pull/${{ inputs.pr_number }}/head" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag_name }}"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ inputs.tag_name || github.ref_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # electron-builder derives its release tag from package.json version (v<version>),
+          # so we strip the leading "v" to feed it back in during the build step.
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-latest
+            script: electron:dist:linux:x64
+          - name: linux-arm64
+            os: ubuntu-latest
+            script: electron:dist:linux:arm64
+          - name: linux-arm
+            os: ubuntu-latest
+            script: electron:dist:linux:arm
+          - name: mac-x64
+            os: macos-latest
+            script: electron:dist:mac:x64
+          - name: mac-arm64
+            os: macos-latest
+            script: electron:dist:mac:arm64
+          - name: win
+            os: windows-latest
+            script: electron:dist:win
+
+    runs-on: ${{ matrix.os }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Apply pre-release version + flag
+        env:
+          REL_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # Pin the package.json version to the requested tag and force every
+          # publish target to "prerelease" so the GitHub release is flagged as such.
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.version = process.env.REL_VERSION;
+            const markPrerelease = (node) => {
+              if (!node || typeof node !== "object") return;
+              if (node.publish && node.publish.releaseType) node.publish.releaseType = "prerelease";
+              for (const key of Object.keys(node)) markPrerelease(node[key]);
+            };
+            markPrerelease(pkg.build || {});
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("Building pre-release v" + pkg.version);
+          '
+
+      - name: Build
+        run: npm run install-all
+
+      - name: Publish pre-release
+        run: npm run ${{ matrix.script }} -- --publish always

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,6 +24,8 @@ defaults:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       ref: ${{ steps.meta.outputs.ref }}
       tag: ${{ steps.meta.outputs.tag }}
@@ -48,6 +50,30 @@ jobs:
           # electron-builder derives its release tag from package.json version (v<version>),
           # so we strip the leading "v" to feed it back in during the build step.
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.ref }}
+
+      - name: Create the pre-release up front
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # The build matrix runs in parallel and each electron-builder invocation
+          # would otherwise try to create the release itself, racing into a 422
+          # "already_exists" on the tag. Creating it once here means every build job
+          # just uploads its assets to an existing release.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, reusing it."
+          else
+            gh release create "$TAG" \
+              --prerelease \
+              --target "$GITHUB_SHA" \
+              --title "$TAG" \
+              --notes "Automated pre-release build."
+          fi
 
   build:
     needs: prepare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [1.2.14](https://github.com/debba/storytel-player/compare/v1.2.13...v1.2.14) (2026-05-15)
 
 
+### Features
+
+* **sso:** add SSO login flow and offline fallbacks ([abdbe98](https://github.com/debba/storytel-player/commit/abdbe98e8edb4477ad909e033c5b12aee8661377))
+
+
 ### Bug Fixes
 
 * **server:** encode Storytel login params ([da15430](https://github.com/debba/storytel-player/commit/da15430f6b5e5bfc53c916c0c3f1158d04022eeb))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.2.15](https://github.com/debba/storytel-player/compare/v1.2.15-beta1...v1.2.15) (2026-07-10)
+
+
+### Bug Fixes
+
+* **bookmarks:** close create bookmark modal on cancel/close ([d130f52](https://github.com/debba/storytel-player/commit/d130f52c6f85225a4ed8d28359ddb004247d9179))
+
+
+### Features
+
+* **storytel:** migrate bookshelf and book details to api.storytel.net ([45e98fc](https://github.com/debba/storytel-player/commit/45e98fcee9bbbc937193b9520d385f8571cdd493))
+* **storytel:** stream audio via api.storytel.net assets endpoint ([de62e46](https://github.com/debba/storytel-player/commit/de62e46af97eb3a7e82c8f5d38bbb21a5e551435))
+
 ## [1.2.14](https://github.com/debba/storytel-player/compare/v1.2.13...v1.2.14) (2026-05-15)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <img src="docs/assets/og_image.png" width="90%"></img>
 
 ## Release Download:
-[![Windows](https://img.shields.io/badge/Windows-Download-blue?logo=windows)](https://github.com/debba/storytel-player/releases/download/v1.2.14/Storytel-Player-Setup-1.2.14.exe) [![macOS Intel](https://img.shields.io/badge/macOS_Intel-Download-black?logo=apple)](https://github.com/debba/storytel-player/releases/download/v1.2.14/Storytel-Player-1.2.14.dmg) [![macOS Apple Silicon](https://img.shields.io/badge/macOS_Apple_Silicon-Download-black?logo=apple)](https://github.com/debba/storytel-player/releases/download/v1.2.14/Storytel-Player-1.2.13-arm64.dmg) [![Linux](https://img.shields.io/badge/Linux-Download-green?logo=linux)](https://github.com/debba/storytel-player/releases/download/v1.2.14/Storytel-Player-1.2.14.AppImage)
+[![Windows](https://img.shields.io/badge/Windows-Download-blue?logo=windows)](https://github.com/debba/storytel-player/releases/download/v1.2.15/Storytel-Player-Setup-1.2.15.exe) [![macOS Intel](https://img.shields.io/badge/macOS_Intel-Download-black?logo=apple)](https://github.com/debba/storytel-player/releases/download/v1.2.15/Storytel-Player-1.2.15.dmg) [![macOS Apple Silicon](https://img.shields.io/badge/macOS_Apple_Silicon-Download-black?logo=apple)](https://github.com/debba/storytel-player/releases/download/v1.2.15/Storytel-Player-1.2.13-arm64.dmg) [![Linux](https://img.shields.io/badge/Linux-Download-green?logo=linux)](https://github.com/debba/storytel-player/releases/download/v1.2.15/Storytel-Player-1.2.15.AppImage)
 
 ## What's New
 

--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron/Chromium needs JIT and executable memory to run the renderer. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- Required so the hardened runtime allows loading unsigned native node modules. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/client/src/components/BookCard.tsx
+++ b/client/src/components/BookCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatMicrosecondsTime, formatTime} from "../utils/helpers";
+import {buildCoverUrl, formatMicrosecondsTime, formatTime} from "../utils/helpers";
 import {BookShelfEntity} from "../interfaces/books";
 import {useTranslation} from "react-i18next";
 
@@ -28,7 +28,7 @@ function BookCard({book, onBookSelect}: BookCardProps) {
             <div className="flex items-center space-x-4">
                 <div className="flex-shrink-0 flex flex-col">
                     <img
-                        src={"https://www.storytel.com" + (book.book.largeCover || book.book.largeCoverE)}
+                        src={buildCoverUrl(book.book.largeCover || book.book.largeCoverE)}
                         alt={book.book.name}
                         className="w-32 h-32 object-cover rounded-lg shadow-lg mb-2"
                     />

--- a/client/src/components/BookInfo.tsx
+++ b/client/src/components/BookInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTranslation} from 'react-i18next';
-import {formatTimeNatural} from '../utils/helpers';
+import {buildCoverUrl, formatTimeNatural} from '../utils/helpers';
 import {BookShelfEntity} from '../interfaces/books';
 import {Chapter} from '../interfaces/chapters';
 
@@ -43,7 +43,7 @@ const BookInfo: React.FC<BookInfoProps> = ({
         <div className="flex flex-col items-center">
             <div className="flex flex-col items-center mb-2">
                 <img
-                    src={"https://www.storytel.com" + (book.book.largeCover || book.book.largeCoverE)}
+                    src={buildCoverUrl(book.book.largeCover || book.book.largeCoverE)}
                     alt={book.book.name}
                     className="w-64 h-64 object-cover rounded-lg shadow-2xl mb-4"
                 />

--- a/client/src/components/BookView.tsx
+++ b/client/src/components/BookView.tsx
@@ -5,11 +5,12 @@ import {BookShelfEntity} from "../interfaces/books";
 import LoadingState from './LoadingState';
 import ErrorState from './ErrorState';
 import Navbar from './Navbar';
-import {truncateTitle} from '../utils/helpers';
+import {buildCoverUrl, localizedLanguageName, truncateTitle} from '../utils/helpers';
+import api from '../utils/api';
 import "../types/window.d.ts";
 
 function BookView() {
-    const {t} = useTranslation();
+    const {t, i18n} = useTranslation();
     const {bookId} = useParams();
     const location = useLocation();
     const navigate = useNavigate();
@@ -20,6 +21,11 @@ function BookView() {
 
     const book: BookShelfEntity = location.state?.book;
 
+    // description and language are not part of the bookshelf payload; they come
+    // from the per-book book-details endpoint, fetched lazily below.
+    const [description, setDescription] = useState('');
+    const [language, setLanguage] = useState('');
+
     useEffect(() => {
         if (book) {
             document.title = truncateTitle(book.book.name);
@@ -29,6 +35,26 @@ function BookView() {
             document.title = 'Storytel Player';
         };
     }, [book]);
+
+    // Fetch description and language from the book-details endpoint.
+    useEffect(() => {
+        const consumableId = book?.book?.consumableId;
+        if (!consumableId) return;
+        let cancelled = false;
+        api.get(`/book-details/${consumableId}`)
+            .then((res) => {
+                if (cancelled) return;
+                const data = res.data || {};
+                setDescription(data.description || '');
+                setLanguage(localizedLanguageName(data.language, i18n.language));
+            })
+            .catch(() => {
+                /* keep empty fallbacks on failure */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [book, i18n.language]);
 
     const handlePlayBook = () => {
         navigate(`/player/${bookId}`, {state: {book}});
@@ -53,7 +79,6 @@ function BookView() {
     };
 
     const getTruncatedDescription = () => {
-        const description = book.abook.description || '';
         if (!description) return t('bookView.noDescription');
 
         if (description.length <= 250 || showFullDescription) {
@@ -64,7 +89,6 @@ function BookView() {
     };
 
     const shouldShowMoreButton = () => {
-        const description = book.abook.description || '';
         return description.length > 250;
     };
 
@@ -80,7 +104,7 @@ function BookView() {
                     {/* Book Cover */}
                     <div className="mb-6">
                         <img
-                            src={"https://www.storytel.com" + (book.book.largeCover || book.book.largeCoverE)}
+                            src={buildCoverUrl(book.book.largeCover || book.book.largeCoverE)}
                             alt={book.book.name}
                             className="w-64 h-64 object-cover rounded-lg shadow-2xl"
                         />
@@ -126,7 +150,7 @@ function BookView() {
                     <div className="w-full max-w-md space-y-2 text-sm">
                         <div className="flex justify-between py-2 border-b border-gray-800">
                             <span className="text-gray-400">{t('bookView.language')}</span>
-                            <span className="text-white">{book.book.language.localizedName}</span>
+                            <span className="text-white">{language}</span>
                         </div>
                         <div className="flex justify-between py-2 border-b border-gray-800">
                             <span className="text-gray-400">{t('bookView.duration')}</span>

--- a/client/src/components/PlayerView.tsx
+++ b/client/src/components/PlayerView.tsx
@@ -381,7 +381,7 @@ function PlayerView() {
                             newBookmarkNote={bookmarks.newBookmarkNote}
                             currentTime={audioPlayer.currentTime}
                             playbackRate={playbackRate}
-                            onCloseCreateBookmarkModal={() => bookmarks.setShowBookmarksModal(false)}
+                            onCloseCreateBookmarkModal={bookmarks.handleCloseCreateBookmarkModal}
                             onNewBookmarkNoteChange={bookmarks.setNewBookmarkNote}
                             onCreateBookmark={() => bookmarks.createBookmark(audioPlayer.currentTime)}
                             showEditBookmarkModal={bookmarks.showEditBookmarkModal}

--- a/client/src/hooks/useAudioPlayer.ts
+++ b/client/src/hooks/useAudioPlayer.ts
@@ -59,14 +59,14 @@ export const useAudioPlayer = ({bookId, consumableId, playbackRate, onLoadError}
     const loadAudioStream = useCallback(async () => {
         try {
             setIsLoading(true);
-            const response = await api.post('/stream', {bookId});
+            const response = await api.post('/stream', {bookId, consumableId});
             setAudioSrc(response.data.streamUrl);
         } catch (err: any) {
             onLoadError(err.response?.data?.error || 'Failed to load audio');
         } finally {
             setIsLoading(false);
         }
-    }, [bookId, onLoadError]);
+    }, [bookId, consumableId, onLoadError]);
 
     const updatePosition = useCallback(async () => {
         if (!audioRef.current || !consumableId) return;

--- a/client/src/hooks/useBookmarks.ts
+++ b/client/src/hooks/useBookmarks.ts
@@ -58,6 +58,11 @@ export const useBookmarks = ({consumableId, onError}: UseBookmarksProps) => {
         setShowCreateBookmarkModal(true);
     };
 
+    const handleCloseCreateBookmarkModal = () => {
+        setShowCreateBookmarkModal(false);
+        setNewBookmarkNote('');
+    };
+
     const handleCloseEditBookmarkModal = () => {
         setShowEditBookmarkModal(false);
         setBookmarkToEdit(null);
@@ -139,6 +144,7 @@ export const useBookmarks = ({consumableId, onError}: UseBookmarksProps) => {
         handleShowEditBookmarkModal,
         handleShowDeleteConfirmModal,
         handleShowCreateBookmarkModal,
+        handleCloseCreateBookmarkModal,
         handleCloseEditBookmarkModal,
         handleCloseDeleteConfirmModal,
         createBookmark,

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,3 +1,23 @@
+// Build a usable cover URL. The new bookshelf API returns absolute URLs
+// (https://covers.storytel.com/...); the legacy API returned relative paths
+// that needed the www.storytel.com host prepended. Storytel only serves the
+// 640px variant, so there is no smaller size to request.
+export const buildCoverUrl = (cover?: string | null): string => {
+    if (!cover) return '';
+    return /^https?:\/\//.test(cover) ? cover : `https://www.storytel.com${cover}`;
+};
+
+// Turn an ISO language code (e.g. "de") into a name localized in the given UI
+// locale (e.g. "Deutsch"/"Tedesco"). Falls back to the raw code if unsupported.
+export const localizedLanguageName = (code?: string | null, uiLocale = 'en'): string => {
+    if (!code) return '';
+    try {
+        return new Intl.DisplayNames([uiLocale], {type: 'language'}).of(code) || code;
+    } catch {
+        return code;
+    }
+};
+
 export const formatTime = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storytel-player",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "storytel-player",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "license": "MIT",
       "dependencies": {
         "dot-object": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
     "mac": {
       "category": "public.app-category.audio",
       "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "assets/entitlements.mac.plist",
+      "entitlementsInherit": "assets/entitlements.mac.plist",
+      "notarize": true,
       "publish": {
         "provider": "github",
         "releaseType": "draft"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storytel-player",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "email": "andrea@debbaweb.it",
   "description": "Storytel Unofficial Player - Storytel audiobook player for desktop",
   "main": "dist/electron/main.js",

--- a/server/fastify-common.ts
+++ b/server/fastify-common.ts
@@ -445,6 +445,25 @@ fastify.get<{
 
 
 
+fastify.get<{
+  Params: { consumableId: string };
+}>(
+  "/api/book-details/:consumableId",
+  {
+    preHandler: fastify.authenticate,
+  },
+  async (request, reply) => {
+    try {
+      const { consumableId } = request.params;
+      const storytelClient = hydrateStorytelClient(request.user);
+      const details = await storytelClient.getBookDetails(consumableId);
+      reply.send(details);
+    } catch (error: any) {
+      replyError(reply, error);
+    }
+  },
+);
+
 // Route per controllare stato autenticazione
 fastify.get("/api/auth/status", async (request, reply) => {
   try {

--- a/server/fastify-common.ts
+++ b/server/fastify-common.ts
@@ -215,7 +215,7 @@ fastify.get(
 
 // Route per ottenere stream URL
 fastify.post<{
-  Body: { bookId: string };
+  Body: { bookId: string; consumableId?: string };
 }>(
   "/api/stream",
   {
@@ -223,7 +223,7 @@ fastify.post<{
   },
   async (request, reply) => {
     try {
-      const { bookId } = request.body;
+      const { bookId, consumableId } = request.body;
       const localFilePath = path.join(DOWNLOADS_DIR, `${bookId}.mp3`);
 
       // Check if file exists locally
@@ -254,7 +254,11 @@ fastify.post<{
         }
       } else {
         const storytelClient = hydrateStorytelClient(request.user);
-        const streamUrl = await storytelClient.getStreamUrl(bookId);
+        // Prefer the new api.storytel.net assets endpoint (needs consumableId);
+        // fall back to the legacy programId-based stream if not provided.
+        const streamUrl = consumableId
+          ? await storytelClient.getAudioStreamUrl(consumableId)
+          : await storytelClient.getStreamUrl(bookId);
         reply.send({ streamUrl, remote: true });
       }
     } catch (error: any) {

--- a/server/storytelApi.ts
+++ b/server/storytelApi.ts
@@ -28,11 +28,76 @@ interface StorytelAuthError extends Error {
   isLoginFailure?: boolean;
 }
 
+// --- Bookshelf ---------------------------------------------------------------
+
+// Raw shape returned by POST https://api.storytel.net/libraries/bookshelf
+interface RawBookshelfNamedEntity {
+  id: string;
+  name: string;
+  deepLink?: string;
+}
+
+interface RawBookshelfFormat {
+  id: string;
+  type: "abook" | "ebook";
+  durationInMilliseconds?: number;
+  durationInCharacters?: number;
+  cover?: { url: string; width: number; height: number };
+  position?: { position: number; updatedTime: string; kidsMode: boolean };
+}
+
+interface RawBookshelfModel {
+  id: string;
+  title: string;
+  state: "CONSUMING" | "CONSUMED" | "WILL_CONSUME" | string;
+  kidsBook?: boolean;
+  authors?: RawBookshelfNamedEntity[];
+  narrators?: RawBookshelfNamedEntity[];
+  formats?: RawBookshelfFormat[];
+  category?: { id: number; name: string };
+}
+
+interface RawBookshelfResponse {
+  items?: Record<string, { action: string; model: RawBookshelfModel }>;
+  followingItems?: Record<string, unknown>;
+  collections?: Record<string, unknown>;
+}
+
+// Subset of the legacy BookShelfEntity (client/src/interfaces/books.ts) that
+// the frontend actually reads. Keep the keys aligned with that interface so
+// the React app keeps working unchanged.
+interface BookShelfEntity {
+  id: string;
+  status: number;
+  book: {
+    name: string;
+    authorsAsString: string;
+    consumableId: string;
+    largeCover: string;
+    largeCoverE: string;
+    category: { title: string };
+    language: { localizedName: string };
+  };
+  abook: {
+    id: string;
+    narratorAsString: string;
+    time: number;
+    description: string;
+  } | null;
+  abookMark: { pos: number } | null;
+  ebook: RawBookshelfFormat | null;
+}
+
+interface BookShelfResponse {
+  books: BookShelfEntity[];
+}
+
 class StorytelClient {
   private client: AxiosInstance;
   public loginData: LoginData;
   private ssoSession: SsoSession | null = null;
-  private cachedFirebaseIdToken: { token: string; expiresAt: number } | null = null;
+  private cachedFirebaseIdToken: { token: string; expiresAt: number } | null =
+    null;
 
   constructor() {
     this.client = axios.create({
@@ -158,7 +223,7 @@ class StorytelClient {
     // Mark legacy credentials as unset so any accidental fallback path errors
     // visibly instead of using stale data.
     this.loginData = {
-      accountInfo: { jwt: '', singleSignToken: '' },
+      accountInfo: { jwt: "", singleSignToken: "" },
     };
   }
 
@@ -176,16 +241,19 @@ class StorytelClient {
 
   private async ensureFirebaseIdToken(): Promise<string> {
     if (!this.ssoSession) {
-      throw new Error('ensureFirebaseIdToken called outside SSO mode');
+      throw new Error("ensureFirebaseIdToken called outside SSO mode");
     }
     const now = Math.floor(Date.now() / 1000);
     const cached = this.cachedFirebaseIdToken;
-    if (cached && cached.expiresAt - FIREBASE_ID_TOKEN_TTL_BUFFER_SECONDS > now) {
+    if (
+      cached &&
+      cached.expiresAt - FIREBASE_ID_TOKEN_TTL_BUFFER_SECONDS > now
+    ) {
       return cached.token;
     }
     const params = new URLSearchParams();
-    params.set('grant_type', 'refresh_token');
-    params.set('refresh_token', this.ssoSession.firebaseRefreshToken);
+    params.set("grant_type", "refresh_token");
+    params.set("refresh_token", this.ssoSession.firebaseRefreshToken);
     try {
       const response = await axios.post<{
         access_token: string;
@@ -196,12 +264,12 @@ class StorytelClient {
         params.toString(),
         {
           headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
+            "Content-Type": "application/x-www-form-urlencoded",
             Referer: FIREBASE_REFERER,
-            Origin: 'https://www.storytel.com',
+            Origin: "https://www.storytel.com",
           },
           timeout: 15000,
-        }
+        },
       );
       const accessToken = response.data.access_token;
       const expiresIn = parseInt(response.data.expires_in, 10) || 3600;
@@ -213,7 +281,7 @@ class StorytelClient {
     } catch (error: any) {
       const status = error.response?.status;
       if (status === 400 || status === 401 || status === 403) {
-        const authError: any = new Error('Firebase refresh token rejected');
+        const authError: any = new Error("Firebase refresh token rejected");
         authError.isStorytelUnauthorized = true;
         throw authError;
       }
@@ -284,21 +352,107 @@ class StorytelClient {
     }
   }
 
-  async getBookshelf(): Promise<any> {
-    const url = `https://www.storytel.com/api/getBookShelf.action?token=${encodeURIComponent(this.getLegacyActionToken())}`;
+  async getBookshelf(): Promise<BookShelfResponse> {
+    const url = `https://api.storytel.net/libraries/bookshelf`;
 
     try {
-      const response = await this.client.get(url);
-      return {
-        ...response.data,
-        books: response.data.books.filter(
-          (book: { status: number }) => book.status === 2 || book.status === 1,
-        ),
+      const bearer = await this.getApiBearer();
+      const response = await this.client.post<RawBookshelfResponse>(
+        url,
+        { items: [] },
+        {
+          headers: {
+            Authorization: `Bearer ${bearer}`,
+            "content-type": "application/x-www-form-urlencoded",
+            Accept: "*/*",
+          },
+        },
+      );
+
+      // The endpoint returns { items: { "<id>": { action, model } } } with a
+      // shape that differs from the legacy getBookShelf.action response. Remap
+      // each `model` onto the legacy BookShelfEntity keys so the existing
+      // frontend keeps working unchanged.
+      const items = response.data?.items;
+      if (!items || typeof items !== "object") return { books: [] };
+
+      // Library state -> legacy numeric status (1 = in progress / to read,
+      // 2 = finished). The Dashboard keeps only {1,2} by default.
+      const stateToStatus: Record<string, number> = {
+        CONSUMING: 1,
+        WILL_CONSUME: 1,
+        CONSUMED: 2,
       };
+
+      const books = Object.values(items)
+        .map((entry) => entry?.model)
+        .filter(Boolean)
+        .map((model): BookShelfEntity => {
+          const formats: RawBookshelfFormat[] = Array.isArray(model.formats)
+            ? model.formats
+            : [];
+          const abookFormat = formats.find((f) => f.type === "abook");
+          const ebookFormat = formats.find((f) => f.type === "ebook");
+          const coverUrl =
+            abookFormat?.cover?.url ?? ebookFormat?.cover?.url ?? "";
+          const join = (arr?: RawBookshelfNamedEntity[]) =>
+            (Array.isArray(arr) ? arr : [])
+              .map((x) => x?.name)
+              .filter(Boolean)
+              .join(", ");
+
+          return {
+            id: model.id,
+            status: stateToStatus[model.state] ?? 1,
+            book: {
+              name: model.title,
+              authorsAsString: join(model.authors),
+              consumableId: String(model.id),
+              // Full absolute URL (covers.storytel.com). See note below.
+              largeCover: coverUrl,
+              largeCoverE: "",
+              category: { title: model.category?.name ?? "" },
+              language: { localizedName: "" },
+            },
+            abook: abookFormat
+              ? {
+                  id: abookFormat.id,
+                  narratorAsString: join(model.narrators),
+                  // Legacy frontend expects microseconds; API gives ms.
+                  time: (abookFormat.durationInMilliseconds ?? 0) * 1000,
+                  description: "",
+                }
+              : null,
+            abookMark: abookFormat?.position
+              ? { pos: (abookFormat.position.position ?? 0) * 1000 }
+              : null,
+            ebook: ebookFormat ?? null,
+          };
+        });
+
+      return { books };
     } catch (error: any) {
       if (error.isStorytelUnauthorized) throw error;
       console.error(error);
       throw new Error(`Failed to get bookshelf: ${error.message}`);
+    }
+  }
+
+  async getBookDetails(consumableId: string): Promise<any> {
+    const url = `https://api.storytel.net/book-details/consumables/${consumableId}?kidsMode=false&configVariant=default`;
+
+    try {
+      const bearer = await this.getApiBearer();
+      const response = await this.client.get(url, {
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+          Accept: "*/*",
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.isStorytelUnauthorized) throw error;
+      throw new Error(`Failed to get book details: ${error.message}`);
     }
   }
 

--- a/server/storytelApi.ts
+++ b/server/storytelApi.ts
@@ -473,6 +473,33 @@ class StorytelClient {
     }
   }
 
+  // New api.storytel.net audio endpoint. Returns a 302 redirect to a signed
+  // mp3 URL on the CDN. Keyed by consumableId (not the abook/program id).
+  async getAudioStreamUrl(consumableId: string): Promise<string> {
+    const url = `https://api.storytel.net/assets/v2/consumables/${consumableId}/abook`;
+
+    try {
+      const bearer = await this.getApiBearer();
+      const response = await this.client.get(url, {
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+          Accept: "*/*",
+        },
+      });
+      // maxRedirects is 0 on the client, so a 2xx here is unexpected; prefer
+      // the redirect Location captured below in the catch.
+      return (
+        (response.request as any)?.res?.responseUrl ||
+        response.headers.location
+      );
+    } catch (error: any) {
+      if (error.isStorytelUnauthorized) throw error;
+      const location = error.response?.headers?.location;
+      if (location) return location;
+      throw new Error(`Failed to get audio stream URL: ${error.message}`);
+    }
+  }
+
   async getStreamUrl(bookId: string): Promise<string> {
     const url = `https://www.storytel.com/mp3streamRangeReq?startposition=0&programId=${bookId}&token=${encodeURIComponent(this.getLegacyActionToken())}`;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "1.2.14";
+export const APP_VERSION = "1.2.15";


### PR DESCRIPTION
Release **v1.2.15**.

## Highlights
- feat(storytel): migrate bookshelf and book details to api.storytel.net
- feat(storytel): stream audio via api.storytel.net assets endpoint
- fix(bookmarks): close create bookmark modal on cancel/close
- ci(macos): sign and notarize the app (Developer ID + App Store Connect API-key notarization)

Merging into `master` triggers the Build & Release workflow, which publishes signed & notarized draft releases for all platforms.