### PR TITLE
feat(error): keep header visible and add logout on bookshelf error

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -96,7 +96,18 @@ function Dashboard({onLogout, triggerLogout, setTriggerLogout}: DashboardProps) 
     }
 
     if (error) {
-        return <ErrorState error={error} onRetry={() => window.location.reload()}/>;
+        // Keep the header visible on error so the user can always reach
+        // Settings → Logout even when the bookshelf fails to load.
+        return (
+            <div className="min-h-screen bg-black text-white">
+                <DashboardHeader
+                    onLogout={onLogout}
+                    triggerLogout={triggerLogout}
+                    setTriggerLogout={setTriggerLogout}
+                />
+                <ErrorState error={error} onRetry={() => window.location.reload()} onLogout={onLogout}/>
+            </div>
+        );
     }
 
     return (

--- a/client/src/components/ErrorState.tsx
+++ b/client/src/components/ErrorState.tsx
@@ -1,25 +1,44 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
-// TODO: Define proper interface for ErrorState props
-function ErrorState({ error, onRetry }: { error: any; onRetry?: any }) {
+interface ErrorStateProps {
+  error: any;
+  onRetry?: () => void;
+  onLogout?: () => void;
+}
+
+function ErrorState({ error, onRetry, onLogout }: ErrorStateProps) {
+  const { t } = useTranslation();
   return (
     <div className="min-h-screen bg-black flex items-center justify-center">
       <div className="text-center max-w-md mx-auto px-4">
         <div className="mb-6">
           <svg className="w-16 h-16 text-red-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.5 0L4.268 15.5c-.77.833.192 2.5 1.732 2.5z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.008v.008H12v-.008Z" />
           </svg>
         </div>
-        <div className="text-red-400 text-xl mb-4 font-semibold">Something went wrong</div>
+        <div className="text-red-400 text-xl mb-4 font-semibold">{t('errorState.title')}</div>
         <p className="text-gray-400 mb-6">{error}</p>
         {onRetry && (
           <button
             onClick={onRetry}
             className="bg-orange-600 hover:bg-orange-700 text-white px-6 py-2 rounded-md transition-colors font-medium"
           >
-            Try Again
+            {t('errorState.tryAgain')}
           </button>
-        )}\n      </div>
+        )}
+        {onLogout && (
+          <div className="mt-8">
+            <p className="text-gray-500 text-sm mb-3">{t('errorState.logoutHint')}</p>
+            <button
+              onClick={onLogout}
+              className="bg-gray-700 hover:bg-gray-600 text-white px-6 py-2 rounded-md transition-colors font-medium"
+            >
+              {t('errorState.logout')}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/server/locales/de.json
+++ b/server/locales/de.json
@@ -63,6 +63,12 @@
     "tooltipEdit": "Lesezeichen bearbeiten",
     "tooltipDelete": "Lesezeichen löschen"
   },
+  "errorState": {
+    "title": "Etwas ist schiefgelaufen",
+    "tryAgain": "Erneut versuchen",
+    "logoutHint": "Wenn das Problem weiterhin besteht, melde dich ab",
+    "logout": "Abmelden"
+  },
   "common": {
     "loading": "Wird geladen...",
     "error": "Fehler",

--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -67,6 +67,12 @@
     "tooltipEdit": "Edit bookmark",
     "tooltipDelete": "Delete bookmark"
   },
+  "errorState": {
+    "title": "Something went wrong",
+    "tryAgain": "Try Again",
+    "logoutHint": "If the problem persists, log out",
+    "logout": "Logout"
+  },
   "common": {
     "loading": "Loading...",
     "error": "Error",

--- a/server/locales/es.json
+++ b/server/locales/es.json
@@ -63,6 +63,12 @@
     "tooltipEdit": "Editar marcador",
     "tooltipDelete": "Eliminar marcador"
   },
+  "errorState": {
+    "title": "Algo salió mal",
+    "tryAgain": "Reintentar",
+    "logoutHint": "Si el problema persiste, cierra sesión",
+    "logout": "Cerrar sesión"
+  },
   "common": {
     "loading": "Cargando...",
     "error": "Error",

--- a/server/locales/fr.json
+++ b/server/locales/fr.json
@@ -63,6 +63,12 @@
     "tooltipEdit": "Modifier le marque-page",
     "tooltipDelete": "Supprimer le marque-page"
   },
+  "errorState": {
+    "title": "Une erreur s'est produite",
+    "tryAgain": "Réessayer",
+    "logoutHint": "Si le problème persiste, déconnectez-vous",
+    "logout": "Se déconnecter"
+  },
   "common": {
     "loading": "Chargement...",
     "error": "Erreur",

--- a/server/locales/it.json
+++ b/server/locales/it.json
@@ -67,6 +67,12 @@
     "tooltipEdit": "Modifica bookmark",
     "tooltipDelete": "Elimina bookmark"
   },
+  "errorState": {
+    "title": "Qualcosa è andato storto",
+    "tryAgain": "Riprova",
+    "logoutHint": "Se il problema persiste, effettua il logout",
+    "logout": "Esci"
+  },
   "common": {
     "loading": "Caricamento...",
     "error": "Errore",

--- a/server/locales/sv.json
+++ b/server/locales/sv.json
@@ -63,6 +63,12 @@
     "tooltipEdit": "Redigera bokmärke",
     "tooltipDelete": "Ta bort bokmärke"
   },
+  "errorState": {
+    "title": "Något gick fel",
+    "tryAgain": "Försök igen",
+    "logoutHint": "Om problemet kvarstår, logga ut",
+    "logout": "Logga ut"
+  },
   "common": {
     "loading": "Laddar...",
     "error": "Fel",


### PR DESCRIPTION
## Summary
When the bookshelf fails to load (e.g. a Firebase token refresh error), the error screen previously took over the whole window with no way out, trapping the user. This PR keeps the user in control on any error state.

## Changes
- **Header always visible on error**: the `Dashboard` now renders `DashboardHeader` above `ErrorState`, so Settings → Logout is always reachable.
- **Direct logout button**: `ErrorState` gains an optional `onLogout` prop rendering a hint (*"If the problem persists, log out"*) and a logout button below the error.
- **i18n**: the hardcoded `ErrorState` strings ("Something went wrong", "Try Again") now go through i18next under a new `errorState.*` namespace, added to all 6 locales (en, it, de, es, fr, sv).
- **Bug fixes**:
  - Removed a stray literal `\n` that was rendered after the "Try Again" button.
  - Fixed the malformed warning-triangle icon (switched to Heroicons v2 `exclamation-triangle`).

## Notes
`PlayerView` and `BookView` still use `ErrorState` without the logout button (their retry navigates home), so their behavior is unchanged.