### PR TITLE
fix(sso): add retry logic and error logging for firebase token extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Bug Fixes
+
+* **sso:** add retry logic and error logging for firebase token extraction
+
 ## [1.2.16](https://github.com/debba/storytel-player/compare/v1.2.15...v1.2.16) (2026-07-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [Unreleased]
-
-### Bug Fixes
-
-* **sso:** add retry logic and error logging for firebase token extraction
-
 ## [1.2.16](https://github.com/debba/storytel-player/compare/v1.2.15...v1.2.16) (2026-07-13)
 
 

--- a/src/modules/sso.ts
+++ b/src/modules/sso.ts
@@ -210,12 +210,15 @@ export class SsoManager {
                 const key = entry && entry.fbase_key;
                 if (typeof key === 'string' && key.startsWith('firebase:authUser:') && key.endsWith(':[DEFAULT]')) {
                   const apiKey = key.slice('firebase:authUser:'.length, key.length - ':[DEFAULT]'.length);
-                  const refresh = entry && entry.value && entry.value.stsTokenManager && entry.value.stsTokenManager.refreshToken;
+                  const tokenMgr = entry && entry.value && entry.value.stsTokenManager;
+                  const refresh = tokenMgr && tokenMgr.refreshToken;
                   if (refresh) return { refreshToken: refresh, apiKey };
                 }
               }
+              console.error('[sso] no valid firebase auth entry found');
               return null;
             } catch (e) {
+              console.error('[sso] firebase extraction error:', e && e.message);
               return null;
             }
           })()`,
@@ -247,14 +250,20 @@ export class SsoManager {
           const currentHost = new URL(win.webContents.getURL()).hostname;
           if (currentHost !== 'www.storytel.com') {
             await win.webContents.loadURL(STORYTEL_WWW_STORAGE_TARGET);
-            await new Promise((r) => setTimeout(r, 800));
+            await new Promise((r) => setTimeout(r, 1500));
           }
 
-          const fb = await extractFirebaseRefreshToken();
+          let fb = await extractFirebaseRefreshToken();
+          if (!fb) {
+            console.warn('[sso] firebase token not found on first attempt, retrying after 1s...');
+            await new Promise((r) => setTimeout(r, 1000));
+            fb = await extractFirebaseRefreshToken();
+          }
+
           if (!fb) {
             finish({
               cancelled: false,
-              error: 'Firebase refresh token not found in IndexedDB',
+              error: 'Firebase refresh token not found in IndexedDB after retries',
             });
             return;
           }


### PR DESCRIPTION
## Problem
Firebase token extraction from IndexedDB was failing because the timeout was too short for IndexedDB to respond, and there was no retry logic. This resulted in invalid tokens being passed to API calls, causing 401 Unauthorized errors on all subsequent Storytel API requests.

## Solution
Added retry logic with 1-second delay between attempts and improved error logging to help diagnose failures.

## Changes
- Timeout increased from 800ms to 1500ms for initial IndexedDB read
- Added retry attempt after 1 second if first extraction fails
- Added error logging for better diagnostics
- Updated error message to indicate retries were attempted

## Testing
- Log in with SSO (Google/Apple)
- Verify Firebase token extraction succeeds even on slow systems
- Check that error logs appear if token extraction ultimately fails