### PR TITLE
Fix audiobook download failing with stream URL 404

### DIFF
--- a/client/src/components/PlayerView.tsx
+++ b/client/src/components/PlayerView.tsx
@@ -132,6 +132,7 @@ function PlayerView() {
 
             const response = await api.post('/download', {
                 bookId,
+                consumableId: book?.book?.consumableId,
                 book,
             });
 

--- a/server/fastify-common.ts
+++ b/server/fastify-common.ts
@@ -546,7 +546,7 @@ fastify.get<{
 
 // Route per scaricare il file audio da remoto
 fastify.post<{
-  Body: { bookId: string };
+  Body: { bookId: string; consumableId?: string };
 }>(
   "/api/download",
   {
@@ -554,7 +554,7 @@ fastify.post<{
   },
   async (request, reply) => {
     try {
-      const { bookId } = request.body;
+      const { bookId, consumableId } = request.body;
       const localFilePath = path.join(DOWNLOADS_DIR, `${bookId}.mp3`);
 
       // Check if already exists
@@ -572,7 +572,11 @@ fastify.post<{
 
       // Get stream URL
       const storytelClient = hydrateStorytelClient(request.user);
-      const streamUrl = await storytelClient.getStreamUrl(bookId);
+      // Prefer the new api.storytel.net assets endpoint (needs consumableId);
+      // fall back to the legacy programId-based stream if not provided.
+      const streamUrl = consumableId
+        ? await storytelClient.getAudioStreamUrl(consumableId)
+        : await storytelClient.getStreamUrl(bookId);
 
       // Create AbortController for this download
       const controller = new AbortController();


### PR DESCRIPTION
## Summary
- Download was failing with "Failed to get stream URL: Request failed with status code 404" because the `/api/download` route still used the legacy `mp3streamRangeReq` endpoint, which Storytel has removed.
- The playback route (`/api/stream`) already prefers the new `api.storytel.net` assets endpoint when a `consumableId` is available, falling back to the legacy endpoint otherwise. Applied the same logic to `/api/download`, and updated the client to pass `consumableId` along with `bookId`.

Fixes #26

## Test plan
- [x] Download an audiobook and confirm it completes without the 404 error
- [x] Confirm previously working scenarios (already-downloaded file, cancel download) still behave correctly