### PR TITLE
fix(i18n): localize remaining UI strings

### DIFF
--- a/client/src/components/BookCard.tsx
+++ b/client/src/components/BookCard.tsx
@@ -118,9 +118,9 @@ export function BookCard({ book, onBookSelect, onRemove, onQuickPlay }: BookCard
               {isFinished
                 ? t('dashboard.filters.concluded', 'Concluded')
                 : isStarted
-                ? `${formatMicrosecondsTime(remainingTime)} ${t('bookCard.remaining', 'remaining')}`
+                ? `${formatMicrosecondsTime(remainingTime, { hours: t('search.hours'), minutes: t('search.minutes') })} ${t('bookCard.remaining', 'remaining')}`
                 : totalDuration > 0
-                ? formatMicrosecondsTime(totalDuration)
+                ? formatMicrosecondsTime(totalDuration, { hours: t('search.hours'), minutes: t('search.minutes') })
                 : t('dashboard.filters.notStarted', 'Not started')}
             </span>
             {isStarted && (

--- a/client/src/components/BookInfo.tsx
+++ b/client/src/components/BookInfo.tsx
@@ -60,7 +60,11 @@ const BookInfo: React.FC<BookInfoProps> = ({
                     <div className="text-left flex-1">
                         <p className="text-base text-white">{currentChapter.title}</p>
                         <p className="text-sm text-gray-400">
-                            {formatTimeNatural((currentChapter.end - currentTime) / playbackRate)}
+                            {formatTimeNatural((currentChapter.end - currentTime) / playbackRate, {
+                                hours: t('goto.hours'),
+                                minutes: t('goto.minutes'),
+                                seconds: t('goto.seconds'),
+                            })}
                         </p>
                     </div>
                 )}

--- a/client/src/components/ChaptersModal.tsx
+++ b/client/src/components/ChaptersModal.tsx
@@ -73,7 +73,7 @@ function ChaptersModal({
                   <div className="flex items-center justify-between p-3.5">
                     <div className="flex-1 min-w-0 mr-3">
                       <h4 className="font-medium text-white text-sm truncate">
-                        {chapter.title || `${t('chapters.chapter', 'Kapitel')} ${chapter.number || index + 1}`}
+                        {chapter.title || `${t('chapters.chapter')} ${chapter.number || index + 1}`}
                       </h4>
                       {isCurrentChapter ? (
                         <div className="flex justify-between items-center mt-1">

--- a/client/src/components/ChaptersPopover.tsx
+++ b/client/src/components/ChaptersPopover.tsx
@@ -90,7 +90,7 @@ export function ChaptersPopover({
                     </span>
                   )}
                   <span className="truncate text-left">
-                    {ch.title || `${t('chapters.chapter', 'Kapitel')} ${chNum}`}
+                    {ch.title || `${t('chapters.chapter')} ${chNum}`}
                   </span>
                 </div>
                 <span className="font-mono text-[11px] opacity-70 flex-shrink-0 tabular-nums">

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -54,7 +54,7 @@ export function Dashboard({ onLogout, triggerLogout, setTriggerLogout }: Dashboa
         const offline = await api.get<BookShelfResponse>('/offline/bookshelf');
         setBooks(offline.data?.books || []);
       } catch {
-        setError(err.response?.data?.error || t('dashboard.loadError', 'Failed to load bookshelf'));
+        setError(err.response?.data?.error || t('dashboard.loadError'));
       }
     } finally {
       setIsLoading(false);

--- a/client/src/components/LoadingState.tsx
+++ b/client/src/components/LoadingState.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-function LoadingState({ message = "Loading..." }) {
+interface LoadingStateProps {
+  message: string;
+}
+
+function LoadingState({ message }: LoadingStateProps) {
   return (
     <div className="min-h-screen bg-black flex items-center justify-center">
       <div className="text-center">

--- a/client/src/components/PlayerBar.tsx
+++ b/client/src/components/PlayerBar.tsx
@@ -63,7 +63,7 @@ export function PlayerBar() {
     return null;
   }
 
-  const bookTitle = activeBook?.book?.name || 'Storytel Audiobook';
+  const bookTitle = activeBook?.book?.name || `Storytel ${t('search.audiobook')}`;
   const authorName = activeBook?.book?.authorsAsString || activeBook?.abook?.narratorAsString || '';
   const coverUrl = activeBook?.book?.largeCover || activeBook?.book?.largeCoverE || '';
   const progressPercent = duration > 0 ? Math.min(Math.max((currentTime / duration) * 100, 0), 100) : 0;

--- a/client/src/components/PlayerView.tsx
+++ b/client/src/components/PlayerView.tsx
@@ -231,13 +231,13 @@ function PlayerView() {
                 setIsDownloaded(true);
             } else {
                 if ((response as any)?.data?.error !== 'Download cancelled') {
-                    setError((response as any)?.data?.error || 'Download failed');
+                    setError((response as any)?.data?.error || t('download.failed'));
                 }
             }
         } catch (err: any) {
             const errorMsg = err?.data?.error || err?.response?.data?.error;
             if (errorMsg !== 'Download cancelled' && errorMsg !== 'canceled') {
-                setError(errorMsg || err.message || 'Download failed');
+                setError(errorMsg || err.message || t('download.failed'));
             }
         } finally {
             setIsDownloading(false);
@@ -261,7 +261,7 @@ function PlayerView() {
                 setIsDownloaded(false);
             }
         } catch (err: any) {
-            setError(err.response?.data?.error || err.message || 'Operation failed');
+            setError(err.response?.data?.error || err.message || t('download.operationFailed'));
             setShowDownloadCancelModal(false);
         }
     };

--- a/client/src/components/SearchFilterRail.tsx
+++ b/client/src/components/SearchFilterRail.tsx
@@ -132,9 +132,9 @@ export function SearchFilterRail({
         <div className="space-y-1">
           {[
             { id: 'all' as DurationFilter, label: t('search.allLengths', 'All lengths') },
-            { id: 'under5' as DurationFilter, label: '< 5 h' },
-            { id: '5to15' as DurationFilter, label: '5–15 h' },
-            { id: 'over15' as DurationFilter, label: '> 15 h' },
+            { id: 'under5' as DurationFilter, label: `< 5 ${t('search.hours')}` },
+            { id: '5to15' as DurationFilter, label: `5–15 ${t('search.hours')}` },
+            { id: 'over15' as DurationFilter, label: `> 15 ${t('search.hours')}` },
           ].map((dur) => {
             const isSelected = selectedDuration === dur.id;
             return (

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -492,7 +492,12 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
             const isAdded = addedBooks[book.id];
             const isAdding = addingBookId === book.id;
             const durationText =
-              book.durationMs > 0 ? formatMicrosecondsTime(book.durationMs * 1000) : '';
+              book.durationMs > 0
+                ? formatMicrosecondsTime(book.durationMs * 1000, {
+                    hours: t('search.hours'),
+                    minutes: t('search.minutes'),
+                  })
+                : '';
 
             return (
               <div

--- a/client/src/components/SearchPreviewPane.tsx
+++ b/client/src/components/SearchPreviewPane.tsx
@@ -34,7 +34,12 @@ export function SearchPreviewPane({
   }
 
   const durationText =
-    book.durationMs > 0 ? formatMicrosecondsTime(book.durationMs * 1000) : '—';
+    book.durationMs > 0
+      ? formatMicrosecondsTime(book.durationMs * 1000, {
+          hours: t('search.hours'),
+          minutes: t('search.minutes'),
+        })
+      : '—';
   const languageLabel = book.language
     ? localizedLanguageName(book.language, i18n.language, book.languageName)
     : (book.languageName ? (book.languageName.charAt(0).toUpperCase() + book.languageName.slice(1)) : '—');

--- a/client/src/components/SearchResultList.tsx
+++ b/client/src/components/SearchResultList.tsx
@@ -63,7 +63,12 @@ export function SearchResultList({
           const isAdded = addedBooks[book.id];
           const isAdding = addingBookId === book.id;
           const durationText =
-            book.durationMs > 0 ? formatMicrosecondsTime(book.durationMs * 1000) : '';
+            book.durationMs > 0
+              ? formatMicrosecondsTime(book.durationMs * 1000, {
+                  hours: t('search.hours'),
+                  minutes: t('search.minutes'),
+                })
+              : '';
 
           return (
             <div

--- a/client/src/contexts/AudioContext.tsx
+++ b/client/src/contexts/AudioContext.tsx
@@ -14,6 +14,7 @@ import { BookShelfEntity, BookMetaData } from '../interfaces/books';
 import { Chapter } from '../interfaces/chapters';
 import { BookmarkPositional } from '../interfaces/bookmarks';
 import { extractChaptersFromResponse, generateAudioTracks } from '../utils/chapters';
+import i18n from '../i18n';
 
 interface LocalPosition {
   position: number;
@@ -384,7 +385,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       } catch (err: any) {
         if (requestId !== loadRequestIdRef.current) return;
         console.error('Failed to load audio stream:', err);
-        setError(err.response?.data?.error || err.message || 'Failed to load audio');
+        setError(err.response?.data?.error || err.message || i18n.t('player.loadError'));
         setIsLoading(false);
       }
     },

--- a/client/src/hooks/useAudioPlayer.ts
+++ b/client/src/hooks/useAudioPlayer.ts
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import api, { trackAction } from '../utils/api';
 import storage from '../utils/storage';
 import {BookmarkPositional} from "../interfaces/bookmarks";
+import i18n from '../i18n';
 
 interface LocalPosition {
     position: number;
@@ -62,7 +63,7 @@ export const useAudioPlayer = ({bookId, consumableId, playbackRate, onLoadError}
             const response = await api.post('/stream', {bookId, consumableId});
             setAudioSrc(response.data.streamUrl);
         } catch (err: any) {
-            onLoadError(err.response?.data?.error || 'Failed to load audio');
+            onLoadError(err.response?.data?.error || i18n.t('player.loadError'));
         } finally {
             setIsLoading(false);
         }

--- a/client/src/hooks/useChapters.ts
+++ b/client/src/hooks/useChapters.ts
@@ -54,7 +54,7 @@ export const useChapters = ({ consumableId, currentTime, onError }: UseChaptersP
       if (currentTime >= chapter.start && currentTime < chapter.end) {
         return {
           ...chapter,
-          title: chapter.title || `${t('chapters.track', { defaultValue: t('chapters.chapter', { defaultValue: 'Ljudspår' }) })} ${chapter.number}`,
+          title: chapter.title || `${t('chapters.track')} ${chapter.number}`,
         };
       }
     }
@@ -63,7 +63,7 @@ export const useChapters = ({ consumableId, currentTime, onError }: UseChaptersP
     if (currentTime >= last.start) {
       return {
         ...last,
-        title: last.title || `${t('chapters.track', { defaultValue: t('chapters.chapter', { defaultValue: 'Ljudspår' }) })} ${last.number}`,
+        title: last.title || `${t('chapters.track')} ${last.number}`,
       };
     }
 

--- a/client/src/utils/chapters.ts
+++ b/client/src/utils/chapters.ts
@@ -11,7 +11,7 @@ export function normalizeChapters(rawChapters: any[] = []): Chapter[] {
   }
 
   let cumulativeTime = 0;
-  const chapterPrefix = i18n.t('chapters.track', { defaultValue: i18n.t('chapters.chapter', { defaultValue: 'Ljudspår' }) });
+  const chapterPrefix = i18n.t('chapters.track');
 
   return rawChapters.map((raw, index) => {
     const number = Number(raw.number ?? raw.order ?? raw.chapterNumber ?? raw.index ?? index + 1);
@@ -133,7 +133,7 @@ export function generateAudioTracks(totalDurationInSeconds: number): Chapter[] {
     segmentDuration = 900;
   }
 
-  const trackPrefix = i18n.t('chapters.track', { defaultValue: 'Ljudspår' });
+  const trackPrefix = i18n.t('chapters.track');
   const tracks: Chapter[] = [];
   let currentTime = 0;
   let trackNumber = 1;

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -112,27 +112,36 @@ export const formatTime = (seconds: number) => {
 };
 
 
-export const formatMicrosecondsTime = (microseconds: number) => {
+export interface TimeUnitLabels {
+    hours: string;
+    minutes: string;
+    seconds?: string;
+}
+
+export const formatMicrosecondsTime = (
+    microseconds: number,
+    units: TimeUnitLabels
+): string => {
     const totalSeconds = Math.floor(microseconds / 1000 / 1000);
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
-    return `${hours} h ${minutes} min`;
+    return `${hours} ${units.hours} ${minutes} ${units.minutes}`;
 };
 
-export const formatTimeNatural = (seconds: number) => {
+export const formatTimeNatural = (seconds: number, units: Required<TimeUnitLabels>): string => {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     const secs = Math.floor(seconds % 60);
 
     const parts = [];
     if (hours > 0) {
-        parts.push(`${hours}h`);
+        parts.push(`${hours} ${units.hours}`);
     }
     if (minutes > 0) {
-        parts.push(`${minutes}min`);
+        parts.push(`${minutes} ${units.minutes}`);
     }
     if (secs > 0 || parts.length === 0) {
-        parts.push(`${secs}s`);
+        parts.push(`${secs} ${units.seconds}`);
     }
 
     return parts.join(' ');

--- a/server/locales/de.json
+++ b/server/locales/de.json
@@ -160,6 +160,8 @@
     "pause": "Pause",
     "playPause": "Abspielen/Pause",
     "playbackSpeed": "Wiedergabegeschwindigkeit",
+    "about": "Über",
+    "help": "Hilfe",
     "logout": "Abmelden",
     "quit": "Beenden"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Möchten Sie die heruntergeladene Datei wirklich löschen?",
     "deleteWarning": "Sie müssen sie erneut herunterladen, um sie offline anzuhören.",
     "deleteButton": "Datei löschen",
-    "keepButton": "Datei behalten"
+    "keepButton": "Datei behalten",
+    "failed": "Download fehlgeschlagen",
+    "operationFailed": "Die heruntergeladene Datei konnte nicht aktualisiert werden"
   },
   "updater": {
     "available": {

--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -160,6 +160,8 @@
     "pause": "Pause",
     "playPause": "Play/Pause",
     "playbackSpeed": "Playback Speed",
+    "about": "About",
+    "help": "Help",
     "logout": "Logout",
     "quit": "Quit"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Are you sure you want to delete the downloaded file?",
     "deleteWarning": "You will need to download it again to listen offline.",
     "deleteButton": "Delete File",
-    "keepButton": "Keep File"
+    "keepButton": "Keep File",
+    "failed": "Download failed",
+    "operationFailed": "Could not update the downloaded file"
   },
   "updater": {
     "available": {

--- a/server/locales/es.json
+++ b/server/locales/es.json
@@ -160,6 +160,8 @@
     "pause": "Pausar",
     "playPause": "Reproducir/Pausar",
     "playbackSpeed": "Velocidad de reproducción",
+    "about": "Acerca de",
+    "help": "Ayuda",
     "logout": "Cerrar sesión",
     "quit": "Salir"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "¿Estás seguro de que quieres eliminar el archivo descargado?",
     "deleteWarning": "Tendrás que descargarlo de nuevo para escuchar sin conexión.",
     "deleteButton": "Eliminar archivo",
-    "keepButton": "Conservar archivo"
+    "keepButton": "Conservar archivo",
+    "failed": "Error al descargar",
+    "operationFailed": "No se pudo actualizar el archivo descargado"
   },
   "updater": {
     "available": {

--- a/server/locales/fi.json
+++ b/server/locales/fi.json
@@ -160,6 +160,8 @@
     "pause": "Tauko",
     "playPause": "Toista/Tauko",
     "playbackSpeed": "Toistonopeus",
+    "about": "Tietoja",
+    "help": "Ohje",
     "logout": "Kirjaudu ulos",
     "quit": "Lopeta"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Haluatko varmasti poistaa ladatun tiedoston?",
     "deleteWarning": "Sinun on ladattava se uudelleen kuunnellaksesi ilman verkkoyhteyttä.",
     "deleteButton": "Poista tiedosto",
-    "keepButton": "Säilytä tiedosto"
+    "keepButton": "Säilytä tiedosto",
+    "failed": "Lataus epäonnistui",
+    "operationFailed": "Ladattua tiedostoa ei voitu päivittää"
   },
   "updater": {
     "available": {

--- a/server/locales/fr.json
+++ b/server/locales/fr.json
@@ -160,6 +160,8 @@
     "pause": "Pause",
     "playPause": "Lecture/Pause",
     "playbackSpeed": "Vitesse de lecture",
+    "about": "À propos",
+    "help": "Aide",
     "logout": "Se déconnecter",
     "quit": "Quitter"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Êtes-vous sûr de vouloir supprimer le fichier téléchargé ?",
     "deleteWarning": "Vous devrez le télécharger à nouveau pour écouter hors ligne.",
     "deleteButton": "Supprimer le fichier",
-    "keepButton": "Conserver le fichier"
+    "keepButton": "Conserver le fichier",
+    "failed": "Échec du téléchargement",
+    "operationFailed": "Impossible de mettre à jour le fichier téléchargé"
   },
   "updater": {
     "available": {

--- a/server/locales/it.json
+++ b/server/locales/it.json
@@ -160,6 +160,8 @@
     "pause": "Pausa",
     "playPause": "Play/Pausa",
     "playbackSpeed": "Velocità di Riproduzione",
+    "about": "Informazioni",
+    "help": "Aiuto",
     "logout": "Logout",
     "quit": "Esci"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Sei sicuro di voler eliminare il file scaricato?",
     "deleteWarning": "Dovrai scaricarlo nuovamente per ascoltarlo offline.",
     "deleteButton": "Elimina File",
-    "keepButton": "Mantieni File"
+    "keepButton": "Mantieni File",
+    "failed": "Download non riuscito",
+    "operationFailed": "Impossibile aggiornare il file scaricato"
   },
   "updater": {
     "available": {

--- a/server/locales/sv.json
+++ b/server/locales/sv.json
@@ -160,6 +160,8 @@
     "pause": "Pausa",
     "playPause": "Spela/Pausa",
     "playbackSpeed": "Uppspelningshastighet",
+    "about": "Om",
+    "help": "Hjälp",
     "logout": "Logga ut",
     "quit": "Avsluta"
   },
@@ -179,7 +181,9 @@
     "deleteMessage": "Är du säker på att du vill ta bort den nedladdade filen?",
     "deleteWarning": "Du måste ladda ner den igen för att lyssna offline.",
     "deleteButton": "Ta bort fil",
-    "keepButton": "Behåll fil"
+    "keepButton": "Behåll fil",
+    "failed": "Nedladdningen misslyckades",
+    "operationFailed": "Det gick inte att uppdatera den nedladdade filen"
   },
   "updater": {
     "available": {

--- a/src/modules/tray.ts
+++ b/src/modules/tray.ts
@@ -98,7 +98,7 @@ export class TrayManager {
         menuTemplate.push({type: 'separator'});
 
         menuTemplate.push({
-            label: "About",
+            label: i18n.t('tray.about'),
             click: () => {
                 const appInfo: string[] = [];
                 appInfo.push(`storytel-player@${app.getVersion()}\n`);
@@ -114,7 +114,7 @@ export class TrayManager {
                 }
                 dialog.showMessageBoxSync(this.windowManager.getWindow()!, {
                     buttons: ["OK"],
-                    title: "About",
+                    title: i18n.t('tray.about'),
                     normalizeAccessKeys: true,
                     defaultId: 0,
                     cancelId: 0,
@@ -123,10 +123,10 @@ export class TrayManager {
                 });
             }
         }, {
-            label: "Help",
+            label: i18n.t('tray.help'),
             submenu: [
                 {
-                    label: "Github Project",
+                    label: i18n.t('settings.githubRepo'),
                     click: () =>
                         shell.openExternal(
                             "https://github.com/debba/storytel-player"


### PR DESCRIPTION
## Summary
- localize time-unit labels and generated chapter names
- replace hardcoded audio/download error fallbacks with translation keys
- translate About and Help entries in the Electron tray menu
- keep locale files in sync across all supported languages

## Validation
- verified locale key parity across all 7 locale files (236 keys each)
- ran `git diff --check`
- build not run because local client dependencies are missing (`tsc: command not found`)

## Follow-up
- positional i18next fallback strings are intentionally outside this PR and can be handled separately